### PR TITLE
Use absolute  urls in unilogin flow redirects

### DIFF
--- a/app/auth/callback/unilogin/route.ts
+++ b/app/auth/callback/unilogin/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server"
 import { IntrospectionResponse } from "openid-client"
 
+import goConfig from "@/lib/config/config"
 import { getUniloginClient, uniloginClientConfig } from "@/lib/session/oauth/uniloginClient"
 import { getSession, setTokensOnSession } from "@/lib/session/session"
 import { TTokenSet } from "@/lib/types/session"
@@ -52,6 +53,6 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error(error)
     // TODO: Error page or redirect to login page.
-    return Response.redirect("/")
+    return Response.redirect(goConfig("app.url"))
   }
 }

--- a/app/auth/logout/route.ts
+++ b/app/auth/logout/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers"
 import { generators } from "openid-client"
 
+import goConfig from "@/lib/config/config"
 import { getUniloginClient, uniloginClientConfig } from "@/lib/session/oauth/uniloginClient"
 import { getSession } from "@/lib/session/session"
 
@@ -10,7 +11,7 @@ export async function GET() {
   const id_token = cookies().get("go-session:id_token")?.value
   // TODO: Is this where we want to redirect to if id token cannot be resolved?
   if (!id_token) {
-    return Response.redirect("/")
+    return Response.redirect(goConfig("app.url"))
   }
   const client = await getUniloginClient()
   const endSession = client.endSessionUrl({


### PR DESCRIPTION
`Response.redirect` needs absolute url in order to function correctly
