### PR TITLE
Add CI checks before building source docker image

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -8,6 +8,38 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run typescript compile check
+        run: |
+          npx tsc --noEmit
+          if [ $? -ne 0 ]; then
+            echo "TypeScript compilation failed"
+            exit 1
+          fi
+
+      - name: Lint Javascripts
+        run: |
+          yarn lint
+          if [ $? -ne 0 ]; then
+            echo "Linting failed"
+            exit 1
+          fi
+
+      - name: Check Prettier formatting
+        run: |
+          yarn run format:check
+          if [ $? -ne 0 ]; then
+            echo "Prettier formatting check failed"
+            exit 1
+          fi
+
       # Validate the format of the tag. We only want to react on a precise pattern.
       - name: Detect release tag
         id: detect_tag


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-217

#### Description

This could probably be done in a more elegant way, but right now it is possible to build an image that will fail in production. We cannot have that :)
