### PR TITLE
Xstate fixes

### DIFF
--- a/__tests__/search.test.ts
+++ b/__tests__/search.test.ts
@@ -85,31 +85,6 @@ describe("Facet functionality", () => {
     expect(result).toStrictEqual(facetFilters)
   })
 
-  it("getSearchQueryArguments should return an object with search query arguments", () => {
-    const facetFilters = {
-      materialTypesGeneral: ["Book"],
-      mainLanguages: ["Danish", "English"],
-      age: ["Adult"],
-      lixRange: ["0-10", "11-20"],
-      subjects: ["Science", "Math"],
-    }
-
-    const result = getSearchQueryArguments({ q: "Harry Potter", currentPage: 0, facetFilters })
-    expect(result).toStrictEqual({
-      q: { all: "Harry Potter" },
-      offset: 0,
-      limit: 9,
-      filters: {
-        branchId: ["11", "22", "33"],
-        materialTypesGeneral: ["Book"],
-        mainLanguages: ["Danish", "English"],
-        age: ["Adult"],
-        lixRange: ["0-10", "11-20"],
-        subjects: ["Science", "Math"],
-      },
-    })
-  })
-
   it("getFacetTranslation should give a translated facet when given a facet machine name", () => {
     // @ts-ignore
     const translation = getFacetTranslation("LIX")

--- a/__tests__/search.test.ts
+++ b/__tests__/search.test.ts
@@ -1,11 +1,10 @@
 import { ReadonlyURLSearchParams } from "next/navigation"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { getFacetsForSearchRequest } from "@/components/pages/searchPageLayout/helper"
 import { getFacetMachineNames, getFacetTranslation } from "@/components/shared/searchFilters/helper"
 import goConfig from "@/lib/config/goConfig"
 import { FacetFieldEnum } from "@/lib/graphql/generated/fbi/graphql"
-import { correctFacetNames } from "@/lib/machines/search/helpers"
+import { correctFacetNames, transformSearchParamsIntoFilters } from "@/lib/machines/search/helpers"
 
 vi.mock(import("@/lib/config/goConfig"), async importOriginal => {
   const actual = await importOriginal()
@@ -60,7 +59,7 @@ describe("Facet functionality", () => {
     ])
   })
 
-  it("getFacetsForSearchRequest should return an object with facet terms grouped by facet machine names", () => {
+  it("transformSearchParamsIntoFilters should return an object with facet terms grouped by facet machine names", () => {
     const searchParams = new URLSearchParams()
     searchParams.append("materialTypesGeneral", "Book")
     searchParams.append("mainLanguages", "Danish")
@@ -79,7 +78,7 @@ describe("Facet functionality", () => {
       subjects: ["Science", "Math"],
     }
 
-    const result = getFacetsForSearchRequest(searchParams as ReadonlyURLSearchParams)
+    const result = transformSearchParamsIntoFilters(searchParams as ReadonlyURLSearchParams)
     expect(result).toStrictEqual(facetFilters)
   })
 

--- a/__tests__/search.test.ts
+++ b/__tests__/search.test.ts
@@ -1,13 +1,11 @@
 import { ReadonlyURLSearchParams } from "next/navigation"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import {
-  getFacetsForSearchRequest,
-  getSearchQueryArguments,
-} from "@/components/pages/searchPageLayout/helper"
+import { getFacetsForSearchRequest } from "@/components/pages/searchPageLayout/helper"
 import { getFacetMachineNames, getFacetTranslation } from "@/components/shared/searchFilters/helper"
 import goConfig from "@/lib/config/goConfig"
 import { FacetFieldEnum } from "@/lib/graphql/generated/fbi/graphql"
+import { correctFacetNames } from "@/lib/machines/search/helpers"
 
 vi.mock(import("@/lib/config/goConfig"), async importOriginal => {
   const actual = await importOriginal()
@@ -86,8 +84,117 @@ describe("Facet functionality", () => {
   })
 
   it("getFacetTranslation should give a translated facet when given a facet machine name", () => {
-    // @ts-ignore
-    const translation = getFacetTranslation("LIX")
+    const translation = getFacetTranslation("lixRange")
     expect(translation).toBe("Lix")
+  })
+
+  it("correctFacetNames should translate the facet names to input filter valid names", () => {
+    const facets = [
+      {
+        name: "materialTypesGeneral",
+        values: [
+          {
+            key: "podcasts",
+            term: "podcasts",
+            score: 179,
+          },
+        ],
+      },
+      {
+        name: "mainLanguages",
+        values: [
+          {
+            key: "dan",
+            term: "Dansk",
+            score: 238,
+          },
+        ],
+      },
+      {
+        name: "age",
+        values: [
+          {
+            key: "for 10 år",
+            term: "for 10 år",
+            score: 25,
+          },
+        ],
+      },
+      {
+        name: "lix",
+        values: [
+          {
+            key: "22",
+            term: "22",
+            score: 2,
+          },
+        ],
+      },
+      {
+        name: "subjects",
+        values: [
+          {
+            key: "magi",
+            term: "magi",
+            score: 192,
+          },
+        ],
+      },
+    ]
+
+    const result = correctFacetNames(facets)
+
+    expect(result).toStrictEqual([
+      {
+        name: "materialTypesGeneral",
+        values: [
+          {
+            key: "podcasts",
+            term: "podcasts",
+            score: 179,
+          },
+        ],
+      },
+      {
+        name: "mainLanguages",
+        values: [
+          {
+            key: "dan",
+            term: "Dansk",
+            score: 238,
+          },
+        ],
+      },
+      {
+        name: "age",
+        values: [
+          {
+            key: "for 10 år",
+            term: "for 10 år",
+            score: 25,
+          },
+        ],
+      },
+      {
+        name: "lixRange",
+        values: [
+          {
+            key: "22",
+            term: "22",
+            score: 2,
+          },
+        ],
+      },
+      {
+        name: "subjects",
+        values: [
+          {
+            key: "magi",
+            term: "magi",
+            score: 192,
+          },
+        ],
+      },
+    ])
   })
 })

--- a/components/pages/searchPageLayout/SearchPageLayout.tsx
+++ b/components/pages/searchPageLayout/SearchPageLayout.tsx
@@ -16,8 +16,14 @@ const SearchPageLayout = () => {
   const loadMoreRef = useRef(null)
   const isInView = useInView(loadMoreRef)
   const actor = useSearchMachineActor()
-  const { data, isLoadingFacets, isLoadingResults, machineIsReady, searchQuery } =
-    useSearchDataAndLoadingStates()
+  const {
+    data,
+    isLoadingFacets,
+    isLoadingResults,
+    isLoadingMoreResults,
+    machineIsReady,
+    searchQuery,
+  } = useSearchDataAndLoadingStates()
 
   useEffect(() => {
     if (isInView) {
@@ -75,7 +81,7 @@ const SearchPageLayout = () => {
                     </motion.div>
                   )
               )}
-            {isLoadingResults && <SearchResultsGhost />}
+            {isLoadingMoreResults && <SearchResultsGhost />}
           </div>
         </>
       ) : (

--- a/components/pages/searchPageLayout/helper.ts
+++ b/components/pages/searchPageLayout/helper.ts
@@ -1,30 +1,6 @@
-import { GetNextPageParamFunction } from "@tanstack/react-query"
 import { useSelector } from "@xstate/react"
-import { ReadonlyURLSearchParams } from "next/navigation"
 
-import { getFacetMachineNames } from "@/components/shared/searchFilters/helper"
-import goConfig from "@/lib/config/goConfig"
-import { TFilters } from "@/lib/machines/search/types"
 import useSearchMachineActor from "@/lib/machines/search/useSearchMachineActor"
-
-export const getFacetsForSearchRequest = (searchParams: ReadonlyURLSearchParams) => {
-  const facets = goConfig("search.facets")
-  const facetsMachineNames = getFacetMachineNames()
-
-  return facetsMachineNames.reduce(
-    (acc: TFilters, machineName) => {
-      const values = searchParams.getAll(facets[machineName as keyof typeof facets].filter)
-      if (values.length > 0) {
-        return {
-          ...acc,
-          [facets[machineName as keyof typeof facets].filter]: [...values],
-        }
-      }
-      return acc
-    },
-    {} as { [key: string]: keyof TFilters[] }
-  )
-}
 
 export const useSearchDataAndLoadingStates = () => {
   const actor = useSearchMachineActor()

--- a/components/pages/searchPageLayout/helper.ts
+++ b/components/pages/searchPageLayout/helper.ts
@@ -71,8 +71,10 @@ export const useSearchDataAndLoadingStates = () => {
   })
   const isLoadingFacets =
     !data.facets || actor.getSnapshot().matches({ filteringAndSearching: "filter" })
-  const isLoadingResults =
-    !data.search || actor.getSnapshot().matches({ filteringAndSearching: "search" })
+  const isLoadingResults = actor.getSnapshot().matches({ filteringAndSearching: "search" })
+  const isLoadingMoreResults = actor
+    .getSnapshot()
+    .matches({ loadingMoreSearchResults: "searching" })
   const machineIsReady = !actor.getSnapshot().matches("bootstrap")
 
   const selectedFilters = useSelector(actor, snapshot => snapshot.context.selectedFilters)
@@ -83,6 +85,7 @@ export const useSearchDataAndLoadingStates = () => {
     selectedFilters,
     isLoadingFacets,
     isLoadingResults,
+    isLoadingMoreResults,
     machineIsReady,
   }
 }

--- a/components/pages/searchPageLayout/helper.ts
+++ b/components/pages/searchPageLayout/helper.ts
@@ -4,30 +4,8 @@ import { ReadonlyURLSearchParams } from "next/navigation"
 
 import { getFacetMachineNames } from "@/components/shared/searchFilters/helper"
 import goConfig from "@/lib/config/goConfig"
-import { SearchFiltersInput, SearchWithPaginationQuery } from "@/lib/graphql/generated/fbi/graphql"
 import { TFilters } from "@/lib/machines/search/types"
 import useSearchMachineActor from "@/lib/machines/search/useSearchMachineActor"
-
-export const getSearchQueryArguments = ({
-  q,
-  currentPage,
-  facetFilters,
-}: {
-  q: string
-  currentPage: number
-  facetFilters: SearchFiltersInput
-}) => {
-  const limit = goConfig("search.item.limit")
-  return {
-    q: { all: q },
-    offset: currentPage * limit,
-    limit: limit,
-    filters: {
-      branchId: goConfig("search.branch.ids"),
-      ...facetFilters,
-    },
-  }
-}
 
 export const getFacetsForSearchRequest = (searchParams: ReadonlyURLSearchParams) => {
   const facets = goConfig("search.facets")
@@ -46,18 +24,6 @@ export const getFacetsForSearchRequest = (searchParams: ReadonlyURLSearchParams)
     },
     {} as { [key: string]: keyof TFilters[] }
   )
-}
-
-export const getNextPageParamsFunc = (
-  currentPage: number
-): GetNextPageParamFunction<number, SearchWithPaginationQuery> => {
-  const limit = goConfig("search.item.limit")
-
-  return ({ search: { hitcount } }) => {
-    const totalPages = Math.ceil(hitcount / limit)
-    const nextPage = currentPage + 1
-    return currentPage < totalPages ? nextPage : undefined // By returning undefined if there are no more pages, hasNextPage boolean will be set to false
-  }
 }
 
 export const useSearchDataAndLoadingStates = () => {

--- a/components/shared/searchFilters/SearchFiltersColumn.tsx
+++ b/components/shared/searchFilters/SearchFiltersColumn.tsx
@@ -28,6 +28,7 @@ const SearchFiltersColumn = ({ facet, isLast }: SearchFiltersColumnProps) => {
   const [hasOverflow, setHasOverflow] = useState(false)
   const { selectedFilters } = useSearchDataAndLoadingStates()
   const toggleFilter = createToggleFilterCallback(actor)
+  const facetData = actor.getSnapshot().context.facetData
 
   // We show the selected values first in the list
   if (selectedFilters) {
@@ -49,7 +50,7 @@ const SearchFiltersColumn = ({ facet, isLast }: SearchFiltersColumnProps) => {
 
   useEffect(() => {
     setIsExpanded(false)
-  }, [actor.getSnapshot().context.facetData])
+  }, [facetData])
 
   return (
     <>

--- a/components/shared/searchFilters/SearchFiltersColumn.tsx
+++ b/components/shared/searchFilters/SearchFiltersColumn.tsx
@@ -18,37 +18,38 @@ import useSearchMachineActor from "@/lib/machines/search/useSearchMachineActor"
 type SearchFiltersColumnProps = {
   facet: SearchFacetFragment
   isLast: boolean
-  isExpanded: boolean
-  setIsExpanded: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const SearchFiltersColumn = ({
-  facet,
-  isLast,
-  isExpanded,
-  setIsExpanded,
-}: SearchFiltersColumnProps) => {
+const SearchFiltersColumn = ({ facet, isLast }: SearchFiltersColumnProps) => {
   const actor = useSearchMachineActor()
+  const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const facetFilter = facet.name as keyof TFilters
   const elementRef = useRef<HTMLDivElement | null>(null)
   const [hasOverflow, setHasOverflow] = useState(false)
   const { selectedFilters } = useSearchDataAndLoadingStates()
   const toggleFilter = createToggleFilterCallback(actor)
 
-  useEffect(() => {
-    const el = elementRef.current
-    if (el) {
-      const isOverflowing = el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth
-      if (isOverflowing) {
-        setHasOverflow(true)
-      }
-    }
-  }, [elementRef])
-
   // We show the selected values first in the list
   if (selectedFilters) {
     facet.values = sortByActiveFacets(facet, selectedFilters)
   }
+
+  useEffect(() => {
+    const el = elementRef.current
+    if (el) {
+      const isOverflowing = el.scrollHeight > el.clientHeight
+
+      if (isOverflowing) {
+        setHasOverflow(true)
+      } else {
+        setHasOverflow(false)
+      }
+    }
+  }, [elementRef?.current?.scrollHeight])
+
+  useEffect(() => {
+    setIsExpanded(false)
+  }, [actor.getSnapshot().context.facetData])
 
   return (
     <>
@@ -88,7 +89,7 @@ const SearchFiltersColumn = ({
           {hasOverflow && (
             <BadgeButton
               ariaLabel={isExpanded ? "Vis færre" : "Vis flere"}
-              classNames={cn(`pl-3 w-auto flex flex-row items-center self-start  ml-1`)}
+              classNames={cn(`pl-3 w-auto flex flex-row items-center self-start mt-1`)}
               onClick={() => {
                 setIsExpanded(prev => !prev)
               }}>

--- a/components/shared/searchFilters/SearchFiltersColumn.tsx
+++ b/components/shared/searchFilters/SearchFiltersColumn.tsx
@@ -5,6 +5,7 @@ import { AnimateChangeInHeight } from "@/components/shared/animateChangeInHeight
 import BadgeButton from "@/components/shared/badge/BadgeButton"
 import Icon from "@/components/shared/icon/Icon"
 import {
+  createToggleFilterCallback,
   facetTermIsSelected,
   getFacetTranslation,
   sortByActiveFacets,
@@ -32,6 +33,7 @@ const SearchFiltersColumn = ({
   const elementRef = useRef<HTMLDivElement | null>(null)
   const [hasOverflow, setHasOverflow] = useState(false)
   const { selectedFilters } = useSearchDataAndLoadingStates()
+  const toggleFilter = createToggleFilterCallback(actor)
 
   useEffect(() => {
     const el = elementRef.current
@@ -73,9 +75,7 @@ const SearchFiltersColumn = ({
               <BadgeButton
                 key={index}
                 ariaLabel={value.term}
-                onClick={() =>
-                  actor.send({ type: "TOGGLE_FILTER", name: facet.name, value: value.term })
-                }
+                onClick={() => toggleFilter({ name: facet.name, value: value.term })}
                 isActive={facetTermIsSelected({
                   facet: facet.name,
                   term: value.term,

--- a/components/shared/searchFilters/SearchFiltersDesktop.tsx
+++ b/components/shared/searchFilters/SearchFiltersDesktop.tsx
@@ -11,7 +11,7 @@ const SearchFiltersDesktop = ({ facets }: { facets: SearchFacetFragment[] }) => 
     <div className="flex flex-row gap-4">
       {facets.map((facet, index) => {
         const isLast = index === facets.length - 1
-        return <SearchFiltersColumn facet={facet} isLast={isLast} />
+        return <SearchFiltersColumn key={index} facet={facet} isLast={isLast} />
       })}
     </div>
   )

--- a/components/shared/searchFilters/SearchFiltersDesktop.tsx
+++ b/components/shared/searchFilters/SearchFiltersDesktop.tsx
@@ -1,28 +1,17 @@
 "use client"
 
-import React, { Suspense, useState } from "react"
+import React from "react"
 
 import { SearchFacetFragment } from "@/lib/graphql/generated/fbi/graphql"
 
 import SearchFiltersColumn, { SearchFiltersColumnGhost } from "./SearchFiltersColumn"
 
 const SearchFiltersDesktop = ({ facets }: { facets: SearchFacetFragment[] }) => {
-  const [isExpanded, setIsExpanded] = useState<boolean>(false)
-
   return (
     <div className="flex flex-row gap-4">
       {facets.map((facet, index) => {
         const isLast = index === facets.length - 1
-        return (
-          <Suspense key={facet.name} fallback={<p>Loading...</p>}>
-            <SearchFiltersColumn
-              facet={facet}
-              isLast={isLast}
-              isExpanded={isExpanded}
-              setIsExpanded={setIsExpanded}
-            />
-          </Suspense>
-        )
+        return <SearchFiltersColumn facet={facet} isLast={isLast} />
       })}
     </div>
   )

--- a/components/shared/searchFilters/SearchFiltersMobile.tsx
+++ b/components/shared/searchFilters/SearchFiltersMobile.tsx
@@ -1,5 +1,6 @@
 import { useRouter, useSearchParams } from "next/navigation"
 import React, { useState } from "react"
+import { AnyActor, AnyEventObject } from "xstate"
 
 import {
   Accordion,
@@ -10,10 +11,10 @@ import {
 import BadgeButton from "@/components/shared/badge/BadgeButton"
 import Icon from "@/components/shared/icon/Icon"
 import {
+  createToggleFilterCallback,
   getActiveFilters,
   getFacetTranslation,
   shouldShowActiveFilters,
-  toggleFilter,
 } from "@/components/shared/searchFilters/helper"
 import {
   Sheet,
@@ -24,6 +25,7 @@ import {
 } from "@/components/shared/sheet/Sheet"
 import { SearchFacetFragment } from "@/lib/graphql/generated/fbi/graphql"
 import { TFilters } from "@/lib/machines/search/types"
+import useSearchMachineActor from "@/lib/machines/search/useSearchMachineActor"
 
 import { Button } from "../button/Button"
 
@@ -35,6 +37,8 @@ const SearchFiltersMobile = ({ facets }: SearchFiltersMobileProps) => {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isSheetOpen, setIsSheetOpen] = useState(false)
+  const actor = useSearchMachineActor()
+  const toggleFilter = createToggleFilterCallback(actor)
 
   return (
     <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
@@ -59,7 +63,7 @@ const SearchFiltersMobile = ({ facets }: SearchFiltersMobileProps) => {
                 return (
                   <BadgeButton
                     onClick={() => {
-                      toggleFilter(facet.name, value.term, router)
+                      toggleFilter({ name: facet.name, value: value.term })
                     }}
                     key={value.term}
                     ariaLabel={value.term}
@@ -90,7 +94,7 @@ const SearchFiltersMobile = ({ facets }: SearchFiltersMobileProps) => {
                         <BadgeButton
                           onClick={() => {
                             setIsSheetOpen(false)
-                            toggleFilter(facet.name, value.term, router)
+                            toggleFilter({ name: facet.name, value: value.term })
                           }}
                           isActive={!!searchParams.getAll(facet.name).includes(value.term)}
                           key={index}

--- a/components/shared/searchFilters/SearchFiltersMobile.tsx
+++ b/components/shared/searchFilters/SearchFiltersMobile.tsx
@@ -1,6 +1,5 @@
-import { useRouter, useSearchParams } from "next/navigation"
+import { useSearchParams } from "next/navigation"
 import React, { useState } from "react"
-import { AnyActor, AnyEventObject } from "xstate"
 
 import {
   Accordion,
@@ -8,13 +7,12 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/accordion/Accordion"
+import { useSearchDataAndLoadingStates } from "@/components/pages/searchPageLayout/helper"
 import BadgeButton from "@/components/shared/badge/BadgeButton"
 import Icon from "@/components/shared/icon/Icon"
 import {
   createToggleFilterCallback,
-  getActiveFilters,
   getFacetTranslation,
-  shouldShowActiveFilters,
 } from "@/components/shared/searchFilters/helper"
 import {
   Sheet,
@@ -34,9 +32,9 @@ type SearchFiltersMobileProps = {
 }
 
 const SearchFiltersMobile = ({ facets }: SearchFiltersMobileProps) => {
-  const router = useRouter()
   const searchParams = useSearchParams()
   const [isSheetOpen, setIsSheetOpen] = useState(false)
+  const { selectedFilters } = useSearchDataAndLoadingStates()
   const actor = useSearchMachineActor()
   const toggleFilter = createToggleFilterCallback(actor)
 
@@ -56,20 +54,19 @@ const SearchFiltersMobile = ({ facets }: SearchFiltersMobileProps) => {
         </SheetTrigger>
 
         {/* Show currently selected filters */}
-        {shouldShowActiveFilters(facets, searchParams) && (
+        {selectedFilters && (
           <div className="flex flex-row flex-wrap gap-1">
-            {getActiveFilters(facets, searchParams).map(facet => {
-              return facet.values.map(value => {
+            {Object.keys(selectedFilters).map(facet => {
+              const facetName = facet as keyof TFilters
+              return selectedFilters[facetName]?.map(value => {
                 return (
                   <BadgeButton
-                    onClick={() => {
-                      toggleFilter({ name: facet.name, value: value.term })
-                    }}
-                    key={value.term}
-                    ariaLabel={value.term}
+                    onClick={() => toggleFilter({ name: facetName, value })}
+                    key={value}
+                    ariaLabel={value}
                     isActive
                     classNames="flex flex-row items-center pr-1">
-                    {value.term}
+                    {value}
                     <Icon name="close" className="w-[25px]" />
                   </BadgeButton>
                 )

--- a/components/shared/searchFilters/helper.ts
+++ b/components/shared/searchFilters/helper.ts
@@ -1,32 +1,16 @@
 import { flatten } from "lodash"
-import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime"
 import { ReadonlyURLSearchParams } from "next/navigation"
+import { AnyActor, AnyEventObject } from "xstate"
 
 import goConfig from "@/lib/config/goConfig"
 import { FacetFieldEnum, SearchFacetFragment } from "@/lib/graphql/generated/fbi/graphql"
 import { TContext, TFilters } from "@/lib/machines/search/types"
 
-export const toggleFilter = (filterName: string, value: string, router: AppRouterInstance) => {
-  const searchParams = new URLSearchParams(window.location.search)
-
-  if (searchParams.has(filterName)) {
-    const filterValues = [...searchParams.getAll(filterName)]
-    searchParams.delete(filterName)
-
-    if (filterValues.includes(value)) {
-      filterValues.splice(filterValues.indexOf(value), 1)
-    } else {
-      filterValues.push(value)
-    }
-    filterValues.forEach(filterValue => {
-      searchParams.append(filterName, filterValue)
-    })
-  } else {
-    searchParams.append(filterName, value)
+export const createToggleFilterCallback =
+  (actor: AnyActor) =>
+  ({ name, value }: { name: string; value: string }) => {
+    actor.send({ type: "TOGGLE_FILTER", name, value } as AnyEventObject)
   }
-  const searchParamsString = searchParams.toString()
-  router.push("/search" + searchParamsString ? `?${searchParamsString}` : "", { scroll: false })
-}
 
 export const sortByActiveFacets = (facet: SearchFacetFragment, selectedFilters: TFilters) => {
   return [...facet.values].sort((a, b) => {

--- a/components/shared/searchFilters/helper.ts
+++ b/components/shared/searchFilters/helper.ts
@@ -48,9 +48,9 @@ export const getFacetMachineNames = () => {
 }
 
 export const getFacetTranslation = (facetFilter: keyof TFilters) => {
-  const facets = goConfig("search.facets")
-
-  return facets[facetFilter.toUpperCase() as keyof typeof facets].translation || ""
+  const facetsConfig = Object.values(goConfig("search.facets"))
+  const translation = facetsConfig.find(facet => facet.filter === facetFilter)?.translation
+  return translation || ""
 }
 
 export const getActiveFilters = (

--- a/components/shared/searchFilters/helper.ts
+++ b/components/shared/searchFilters/helper.ts
@@ -1,5 +1,3 @@
-import { flatten } from "lodash"
-import { ReadonlyURLSearchParams } from "next/navigation"
 import { AnyActor, AnyEventObject } from "xstate"
 
 import goConfig from "@/lib/config/goConfig"
@@ -35,27 +33,6 @@ export const getFacetTranslation = (facetFilter: keyof TFilters) => {
   const facetsConfig = Object.values(goConfig("search.facets"))
   const translation = facetsConfig.find(facet => facet.filter === facetFilter)?.translation
   return translation || ""
-}
-
-export const getActiveFilters = (
-  allFacets: SearchFacetFragment[],
-  searchParams: ReadonlyURLSearchParams
-) => {
-  const filteredActive = allFacets.map(facet => {
-    const searchFacet = { ...facet }
-    searchFacet.values = searchFacet.values.filter(value => {
-      return searchParams.getAll(facet.name).includes(value.term)
-    })
-    return searchFacet
-  })
-  return filteredActive
-}
-
-export const shouldShowActiveFilters = (
-  facets: SearchFacetFragment[],
-  searchParams: ReadonlyURLSearchParams
-) => {
-  return flatten(getActiveFilters(facets, searchParams).map(filter => filter.values)).length > 0
 }
 
 export const facetTermIsSelected = ({

--- a/components/shared/searchInput/SearchInput.tsx
+++ b/components/shared/searchInput/SearchInput.tsx
@@ -24,28 +24,28 @@ const SearchInput = ({ className, placeholder }: SearchInputProps) => {
   })
 
   useEffect(() => {
-    window.addEventListener("keydown", handleKeydown(currentQuery))
+    window.addEventListener("keydown", handleKeydown())
     return () => {
-      window.removeEventListener("keydown", handleKeydown(currentQuery))
+      window.removeEventListener("keydown", handleKeydown())
     }
     // We choose to ignore the eslint warning below
     // because we do not want to add the handleKeydown callback which changes on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentQuery])
 
-  const handleKeydown = (q: string) => (event: KeyboardEvent) => {
-    if (!q) return
+  const handleKeydown = () => (event: KeyboardEvent) => {
+    if (!currentQuery) return
     const focusedElement = document.activeElement as HTMLElement
 
     if (event.key === "Enter" && focusedElement === inputRef.current) {
-      navigateToSearch(q)()
+      navigateToSearch(currentQuery)
     }
   }
 
-  const navigateToSearch = (q: string) => () => {
+  const navigateToSearch = (q: string) => {
     if (!q) return
     actor.send({ type: "SEARCH" })
-    router.push(currentQuery ? `/search?q=${currentQuery}` : "/search", {
+    router.push(`/search?q=${q}`, {
       scroll: false,
     })
   }
@@ -67,7 +67,7 @@ const SearchInput = ({ className, placeholder }: SearchInputProps) => {
       />
       <button
         className="focus-visible absolute right-3 top-[50%] translate-y-[-50%] rounded-full md:right-[24px]"
-        onClick={navigateToSearch(currentQuery)}
+        onClick={() => currentQuery && navigateToSearch(currentQuery)}
         aria-label="Søg">
         <Icon className="h-[32px] w-[32px]" name="search" />
       </button>

--- a/lib/config/dpl-cms/dplCmsConfig.ts
+++ b/lib/config/dpl-cms/dplCmsConfig.ts
@@ -10,7 +10,7 @@ const queryDplCmsConfig = async (queryClient: QueryClient) => {
     queryKey: useGetDplCmsConfigurationQuery.getKey(),
     queryFn: useGetDplCmsConfigurationQuery.fetcher(),
     // Cache 5 minutes unless invalidated
-    staleTime: 60 * 5,
+    staleTime: 5 * 60 * 1000, // 5 mins
   })
 
   return dplConfiguration ?? null

--- a/lib/getQueryClient.ts
+++ b/lib/getQueryClient.ts
@@ -1,5 +1,15 @@
 import { QueryClient } from "@tanstack/react-query"
 import { cache } from "react"
 
-const getQueryClient = cache(() => new QueryClient())
+const getQueryClient = cache(
+  () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          // TODO: Move this into config.
+          staleTime: 5 * 60 * 1000, // 5 mins
+        },
+      },
+    })
+)
 export default getQueryClient

--- a/lib/machines/search/debug.ts
+++ b/lib/machines/search/debug.ts
@@ -2,6 +2,7 @@ import { InspectionEvent } from "xstate"
 
 export const debugEvents = (inspectionEvent: InspectionEvent) => {
   if (inspectionEvent.type === "@xstate.event") {
+    // eslint-disable-next-line no-console
     console.debug(inspectionEvent.event)
   }
 }

--- a/lib/machines/search/debug.ts
+++ b/lib/machines/search/debug.ts
@@ -1,0 +1,7 @@
+import { InspectionEvent } from "xstate"
+
+export const debugEvents = (inspectionEvent: InspectionEvent) => {
+  if (inspectionEvent.type === "@xstate.event") {
+    console.debug(inspectionEvent.event)
+  }
+}

--- a/lib/machines/search/helpers.ts
+++ b/lib/machines/search/helpers.ts
@@ -1,9 +1,11 @@
+import { ReadonlyURLSearchParams } from "next/navigation"
+
+import { getFacetMachineNames } from "@/components/shared/searchFilters/helper"
 import goConfig from "@/lib/config/goConfig"
+import { SearchFacetsQuery } from "@/lib/graphql/generated/fbi/graphql"
 
 import { TContext, TFilters } from "./types"
 
-// Filters needs to be translated tho the input filters expected by the API
-// For some reason the input filters are different from the filters coming from the search facets request.
 export const getFiltersForSearchRequest = ({ selectedFilters }: TContext): TFilters => {
   const facets = goConfig("search.facets")
   return Object.keys(selectedFilters).reduce((acc, key: string) => {
@@ -15,4 +17,39 @@ export const getFiltersForSearchRequest = ({ selectedFilters }: TContext): TFilt
 
     return acc
   }, {} as TFilters)
+}
+
+// Filters needs to be translated tho the input filters expected by the API
+// For some reason the input filters are different from the filters coming from the search facets request.
+export const correctFacetNames = (facets: SearchFacetsQuery["search"]["facets"]) => {
+  const facetsConfig = goConfig("search.facets")
+  type TFacetConfigKey = keyof typeof facetsConfig
+
+  return facets.map(({ name, ...rest }) => {
+    const configKey = (name as TFacetConfigKey).toUpperCase()
+    const filterName = facetsConfig[configKey as TFacetConfigKey].filter
+    return {
+      ...rest,
+      name: filterName,
+    }
+  })
+}
+
+export const transformSearchParamsIntoFilters = (searchParams: ReadonlyURLSearchParams) => {
+  const facets = goConfig("search.facets")
+  const facetsMachineNames = getFacetMachineNames()
+
+  return facetsMachineNames.reduce(
+    (acc: TFilters, machineName) => {
+      const values = searchParams.getAll(facets[machineName as keyof typeof facets].filter)
+      if (values.length > 0) {
+        return {
+          ...acc,
+          [facets[machineName as keyof typeof facets].filter]: [...values],
+        }
+      }
+      return acc
+    },
+    {} as { [key: string]: keyof TFilters[] }
+  )
 }

--- a/lib/machines/search/helpers.ts
+++ b/lib/machines/search/helpers.ts
@@ -1,0 +1,18 @@
+import goConfig from "@/lib/config/goConfig"
+
+import { TContext, TFilters } from "./types"
+
+// Filters needs to be translated tho the input filters expected by the API
+// For some reason the input filters are different from the filters coming from the search facets request.
+export const getFiltersForSearchRequest = ({ selectedFilters }: TContext): TFilters => {
+  const facets = goConfig("search.facets")
+  return Object.keys(selectedFilters).reduce((acc, key: string) => {
+    const facetConfig = facets[key.toUpperCase() as keyof typeof facets]
+    acc = {
+      ...acc,
+      [facetConfig.filter]: selectedFilters[key as keyof TContext["selectedFilters"]],
+    }
+
+    return acc
+  }, {} as TFilters)
+}

--- a/lib/machines/search/search.machine.setup.ts
+++ b/lib/machines/search/search.machine.setup.ts
@@ -44,21 +44,14 @@ export default setup({
       type: "filterToggled",
       toggled: event,
     })),
-    emitQDeleted: emit(() => ({
-      type: "qDeleted",
-    })),
     setCurrentQueryInContext: assign({
       currentQuery: ({ event }) => event.q,
     }),
-    setSbmittedQueryInContext: assign({
+    setSubmittedQueryInContext: assign({
       submittedQuery: ({ context }) => (context.submittedQuery = context.currentQuery),
     }),
     resetFilters: assign(() => ({
       selectedFilters: {},
-    })),
-    resetQuery: assign(() => ({
-      currentQuery: undefined,
-      submittedQuery: undefined,
     })),
     resetSearchData: assign(() => ({
       searchData: undefined,
@@ -105,9 +98,6 @@ export default setup({
     getFacets,
   },
   guards: {
-    eventHasSearchString: ({ event }) => {
-      return Boolean(event.q && event.q.length > 0)
-    },
     contextHasSearchString: ({ context }) => {
       return Boolean(context.currentQuery && context.currentQuery.length > 0)
     },

--- a/lib/machines/search/search.machine.setup.ts
+++ b/lib/machines/search/search.machine.setup.ts
@@ -1,5 +1,6 @@
 import { assign, emit, setup } from "xstate"
 
+import { correctFacetNames } from "./helpers"
 import { getFacets, performSearch } from "./queries"
 import { TContext, TFilters, TInput } from "./types"
 
@@ -63,7 +64,9 @@ export default setup({
             search: { facets },
           },
         },
-      }) => facets,
+      }) => {
+        return correctFacetNames(facets)
+      },
     }),
     setSearchDataInContext: assign({
       searchData: ({

--- a/lib/machines/search/search.machine.setup.ts
+++ b/lib/machines/search/search.machine.setup.ts
@@ -21,9 +21,16 @@ export default setup({
         }
         // Remove filter.
         if (selectedFilters[filterName] && selectedFilters[filterName].includes(value)) {
+          const updatedFilterTerms = selectedFilters[filterName].filter(
+            filterValue => filterValue !== value
+          )
+          if (updatedFilterTerms.length === 0) {
+            delete selectedFilters[filterName]
+            return selectedFilters
+          }
           return {
             ...selectedFilters,
-            [name]: selectedFilters[filterName].filter(filterValue => filterValue !== value),
+            [name]: updatedFilterTerms,
           }
         }
         // Add filter.

--- a/lib/machines/search/search.machine.ts
+++ b/lib/machines/search/search.machine.ts
@@ -24,7 +24,7 @@ export default searchMachineSetup.createMachine({
           actions: ["setQueryClientInContext"],
         },
         SET_SEARCH_STRING: {
-          actions: ["setCurrentQueryInContext", "setSbmittedQueryInContext"],
+          actions: ["setCurrentQueryInContext", "setSubmittedQueryInContext"],
         },
         SET_INITIAL_FILTERS: {
           actions: ["setInitialFiltersInContext"],
@@ -54,17 +54,13 @@ export default searchMachineSetup.createMachine({
         ],
         TYPING: [
           {
-            guard: "eventHasSearchString",
             actions: ["setCurrentQueryInContext"],
-          },
-          {
-            actions: ["emitQDeleted", "resetQuery"],
           },
         ],
         SEARCH: [
           {
             guard: "contextHasSearchString",
-            actions: ["resetSearchData", "resetFilters", "setSbmittedQueryInContext"],
+            actions: ["resetSearchData", "resetFilters", "setSubmittedQueryInContext"],
             target: "filteringAndSearching",
           },
           {

--- a/lib/machines/search/search.machine.ts
+++ b/lib/machines/search/search.machine.ts
@@ -3,7 +3,7 @@ import { and, not } from "xstate"
 import searchMachineSetup from "./search.machine.setup"
 
 export default searchMachineSetup.createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5SzAQwE4GMAWA6ARgPaEAusJ6qADgMQDKAogCoD6AigKoMBKAmiwGEAMgEkGAOSYBtAAwBdRKCqFYASxKrCAO0UgAHogC0ANgCMAVlwAWAJzGATDIAcNmeYDM9zwBoQAT0QLAHZcYycnIKdTSNcndysAXwTfFAwcAmIyCmp6ZhZGAEFuAQAJfKZuEXEAcVkFJBBlNQ1tXQMEQytjS0cbKyCg0xdwpytzXwCEd2jcGxt3d1Gne273AaSUtCw8IlJySlpGViqRJhECoRYAMREhJh46Ot0m9U0dBvaTR1Cw0ysFpzmLxuCaIKxDXCmdw2cwyFamYyLKIbECpbYZPbZWgAIQA8rimHQKgUAAosAAiuPEDCeDReLXeoE+5iiuCC0Js9isK36phhoIQphkNlC4Ui0RczniphRaPSuyyBxoeIJRO4pIpVJppnqShUr1aHyMLNMbI5XJ5g35-kQZlFESiMSl4NlW3SqggABswDQmLjqtUhAxrrd7txaXrmm82oh4j17C47OYHE5jALHPZcOYuiNxXF3A5XWk8B7vb7-YHgzc7jwpDrnvqGTGEPYgiKvH1ls4gkDugLzBZcAWglygmE22ZjEX0aWfUxeCSqrV5A2o4amcbubM-vY5gsYQiggK21ZIcCZHDjD3wVPkqi3SWvT7CsUShHGo3o0apnEs64HDInj2KYfJxAKiIigOxh9DIgyptCMp3nKj5li+pR1rqH5roy+ixgMkLcjYCLmD2Ep2AKsS4BEMLsi4njuAO07uk+NBCLiBTkiwACyuLcDSK50p+664YKRG4LutjxPYXIXgO9gCiBcxUQ4V7TMsaw2EETF4AAZqonokGA6CqFoUAFFoEB0A+JlQDQEDaGAuDkKghlOQ+uB6QZRk2eZlnWaZ770l+G4dHyMhZuYLJtqmbh-DIVj9qebgjmMgJcg4XTaR5+mGcZpm+VZxY2W5xYldsNl2Q5uAmQAboQADWjnIdlXl5WZFmFeVpllekyE2QgtWEJgLlvHUgVCTh7RCsmsx2MKazjDaLZWE4sz2CRUTrVlnm5T5HX+VAPV4H1pk0EZ6CEOguBUJ6Lk6ZdAC2R0tbt+X7UV3XNSdUADVodXDQyY0CZGBqTYgowhHB7L9OCwHCgpfSzHC8QLdtOXeW9fkfYdO1GS9GO2fZWiOYNjXPbjbUFQd+NXRT-WDQDo3yON2HNkKKzWOt4rrf2QThZKDjmGjrV7VjXU4+jtOSxV52Xddt0kPd6BPc1dOY51ODFRTNP039Q0jdoQOYUFwntBD1hxYL-YIspUNC0h7meoQqAQDZXGXWAGvYNwcAAK4GbAR0VUTJN62TzVOy7bse17PuwP7ZBB6Zv3-QbWhG6uoPNoYfLGNYxjxcY-TmPMnhDBR3zrdmfJ2Ms2b25spWR67pnu+gnsPnHCeB99Z3oBdV03Xdj3Pc30ft7HfsB0nP0M2nGeCaz345wmZ6bbBrYeFYYwKV47jiV0wF-HEfwWEkd5aIQEBwLoyGZ02y+AvvEStsORdWotkwr6e7LJpyXbQSFDYLKCp9jUHvsFEShgnBuCoiOdkV5358k-kYNY4kGJ823utQWMJEgO1KrOCBpsjCmEzOEZMk4xhXjiGEcCMg85rDiAOEu8VhR4MbuiNW7Uxaa1MkQsGCB2QhGBDmHsCMkZeC8DA2EJFuzC1etwr2xU76Lyzt+SIlgPDMKtktIUIQrDI0igxSSK0G73lKlwqm2NnrfX4c2fMWYGIWB0ZMUc1hkb-B7PIgmVjxbPRDnY78pDIhmhPtEK8G1TDpmgqEIEKMvH4M4dLdW1MKaBJCho9BhcIgoIQIRIcV4LTrU0jDW8HD0iWPen47WXD0kiQcSI8cuS-4FLtt4ymVTeES1argAJqiH4hVIQYrMwwgjcgieKfsYkzBtMSekMercY6dynmQOpnxbAiihCXBY0kezxB3rov4lgxkqQygmFwWUFlQDbh3YsXdp62P6ZA9ZA5IQMVLrsreBzJikIWAfBwIEVrTHBPbJIQA */
+  /** @xstate-layout N4IgpgJg5mDOIC5SzAQwE4GMAWA6ARgPaEAusJ6qADgMQDKAogCoD6AigKoMBKAmiwGEAMgEkGAOSYBtAAwBdRKCqFYASxKrCAO0UgAHogC0ANgCMAVlwAWAJzGATDIAcNmeYDM9zwBoQAT0QLAHZcYycnIKdTSNcndysAXwTfFAwcAmIyCmp6ZhZGAEFuAQAJfKZuEXEAcVkFJBBlNQ1tXQMEQytjS0cbKyCg0xdwpytzXwCEd2jcGxt3d1Gne273AaSUtCw8IlJySlpGViqRJhECoRYAMREhJh46Ot0m9U0dBvaTR1Cw0ysFpzmLxuCaIKxDXCmdw2cwyFamYyLKIbECpbYZPbZWgAIQA8rimHQKgUAAosAAiuPEDCeDReLXeoE+5iiuCC0Js9isK36phhoIQphkNlC4Ui0RczniphRaPSuyyBxoeIJRO4pIpVJppnqShUr1aHyMLNMbI5XJ5g35-kQZlFESiMSl4NlW3SqggABswDQmLjqtUhAxrrd7txaXrmm82oh4j17C47OYHE5jALHPZcOYuiNxXF3A5XWk8B7vb7-YHgzc7jwpDrnvqGTGEPYgiKvH1ls4gkDugLzBZcAWglygmE22ZjEX0aWfUxeCSqrV5A2o4amcbubM-vY5gsYQiggK21ZIcCZHDjD3wVPkqi3SWvT7CsUShHGo3o0apnEs64HDInj2KYfJxAKiIigOxh9DIgyptCMp3nKj5li+pR1rqH5roy+ixgMkLcjYCLmD2Ep2AKsS4BEMLsi4njuAO07uk+NBCLiBTkiwACyuLcDSK50p+664YKRG4LutjxPYXIXgO9gCiBcxUQ4V7TMsaw2EETF4AAZqonokGA6CqFoUAFFoEB0A+JlQDQEDaGAuDkKghlOQ+uB6QZRk2eZlnWaZ770l+G4dHyMhZuYLJtqmbh-DIVj9qebgjmMgJcg4XTaR5+mGcZpm+VZxY2b6C5LoFQk4e0CKAZCUKjh4qatk4x5ONYgJXpywoIn8t6bMW2VeXlZkWYV2zFWhb4CZGBqVYEgIhF00knsByymAKhieElfLZqBUREYkSHuZ5uU+SN-m2RNGGrjNzZ8osuBuM4MmmAmXLuMekSzHCaz9D25hzFph39cd3n5WdRWmW5-XIcV9laI5JkAG6EAA1o5yEDSdYN+RDUBQ+iMOmQgSOEJgLlvHU5XYbdbjGLMdjCms4w2i2VitZyJFRPY5hZSDQ0Fed+PpITtlGeghDoLgVCei5OkSwAtkLuk5aDw042NkMYyLxNaMjZMMpTU1YTd36jCEcHsv04LAcKCl9F9Xj-D2vMq-z4Ma3jfOY6rdkObgJNo0r3tu+rOA2cHwc2Trevk9ohuYUFwlVZe1jc+K3P9kE4WSg4PNA+ifOnaH2Dh17hemTQYsS1LMskHL6CKxj5dq6NYeQ2XrtRyT+sU-IVMmyFZvWHFuf9giykW3nfXop6hCoBANlcRLYCt9g3BwAArgZsBK7DfsB+j7mz-Pi-L6v6+wFvZC70T3ex1o8fXU236GHydNdPFxj9P9CwrRR3zcx2nMMI3MxhZWPgvUyS90ArwfBfK+O8RaV3QOLSW0tZYKyDhA0+MDz6b23jfKA0dSb30foJamL8XqtSoS9WCrYPBWDGApLw7hxKLRAmzaY4I853i0IQCAcBdDISfsFEShhASsIiK2YcX8rTM0mJ0ECWZtr-G5BYNYcQsoKn2NQERScjBODcFREc7IryyO2utNY4kGJZ0YdzXOMIDrT2Yt6PRs1QqZnCMmScYwrxxDCOBGQdMNEMQsK4KwwonH3mBp3bGq8bJuObOyEIwIcw9jtg7Lwfw0rzEBFEpusSW6C2EeQgeIlIiWA8AOZMGcWZCgWnCBMY5ohf2gu4F2g0i7xM1u5EWiTTYLCzKEmp8jECjmsN9J2U9okF0KQLXGQc4ZgH6SFF6n1aLTBaT2cU6ZoKhCBPEJmHSsZFIWXzFZ5TATWM-hEUZCBCJDivOlREUjui9RmekZu8yPYR2bhc9o+ZrlpLucmEUw4hjO3zp8uZ7s26e1drgJZ-zAgySzMMII3IryczWizf6pozCT3AXPSBUBoGwOLPA7eyKOi2BFFCH+QEezxCYXUv4lgMUOCzg4IYYQiUnygWfOB+Dr59NKc-EKnQByQgYvMRlDCWWTBeoM9KwFslcIsEkJIQA */
   id: "search",
   initial: "bootstrap",
   context: ({ input }) => ({
@@ -78,6 +78,24 @@ export default searchMachineSetup.createMachine({
     filteringAndSearching: {
       type: "parallel",
       initial: "search",
+      on: {
+        TYPING: [
+          {
+            actions: ["setCurrentQueryInContext"],
+          },
+        ],
+        SEARCH: [
+          {
+            guard: "contextHasSearchString",
+            actions: ["resetSearchData", "resetFilters", "setSubmittedQueryInContext"],
+            target: "filteringAndSearching",
+          },
+          {
+            actions: ["resetFilters"],
+            target: "idle",
+          },
+        ],
+      },
       states: {
         search: {
           initial: "searching",

--- a/lib/machines/search/search.machine.ts
+++ b/lib/machines/search/search.machine.ts
@@ -1,6 +1,5 @@
 import { and, not } from "xstate"
 
-import { getFiltersForSearchRequest } from "./helpers"
 import searchMachineSetup from "./search.machine.setup"
 
 export default searchMachineSetup.createMachine({
@@ -95,7 +94,7 @@ export default searchMachineSetup.createMachine({
                   return {
                     q: context.currentQuery,
                     queryClient: context.queryClient,
-                    filters: getFiltersForSearchRequest(context),
+                    filters: context.selectedFilters,
                     offset: context.searchOffset,
                     limit: context.searchPageSize,
                   }
@@ -125,7 +124,7 @@ export default searchMachineSetup.createMachine({
                   return {
                     q: context.currentQuery,
                     queryClient: context.queryClient,
-                    filters: getFiltersForSearchRequest(context),
+                    filters: context.selectedFilters,
                     facetLimit: context.facetLimit,
                   }
                 },
@@ -160,7 +159,7 @@ export default searchMachineSetup.createMachine({
               return {
                 q: context.currentQuery,
                 queryClient: context.queryClient,
-                filters: getFiltersForSearchRequest(context),
+                filters: context.selectedFilters,
                 offset: context.searchOffset,
                 limit: context.searchPageSize,
               }

--- a/lib/machines/search/search.machine.ts
+++ b/lib/machines/search/search.machine.ts
@@ -1,9 +1,10 @@
 import { and, not } from "xstate"
 
+import { getFiltersForSearchRequest } from "./helpers"
 import searchMachineSetup from "./search.machine.setup"
 
 export default searchMachineSetup.createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5SzAQwE4GMAWA6ARgPaEAusJ6qADgMQDKAogCoD6AigKoMBKAmiwGEAMgEkGAOSYBtAAwBdRKCqFYASxKrCAO0UgAHogC0ANgCMAVlwAWAJzGATDIAcNmeYDM9zwBoQAT0QLAHZcYycnIKdTSNcndysAXwTfFAwcAmIyCmp6ZhZGAEFuAQAJfKZuEXEAcVkFJBBlNQ1tXQMEQytjS0cbKyCg0xdwpytzXwCEd2jcGxt3d1Gne273AaSUtCw8IlJySlpGViqRJhECoRYAMREhJh46Ot0m9U0dBvaTR1Cw0ysFpzmLxuCaIKxDXCmdw2cwyFamYyLKIbECpbYZPbZWgAIQA8rimHQKgUAAosAAiuPEDCeDReLXeoE+5iiuCC0Js9isK36phhoIQphkNlC4Ui0RczniphRaPSuyyBxoeIJRO4pIpVJppnqShUr1aHyMLNMbI5XJ5g35-kQZlFESiMSl4NlW3SqggABswDQmLjqtUhAxrrd7txaXrmm82mD7CL2V4FjZwt0rFYBfZ7E5cB5hXzPOYhdN3K60ngPd7ff7A8GbnceFIdc99QyYwh7EERV4+stnEEgd0BYXLO5jEEuUEwp2zMZS+iKz6mLwSVVavJm1HDUzjdzZn84-NoYWxwLO1ZIcCZHCx+ZwbPkqi3eWvYvl6vG7rGi3o0bBUEZKEfwAu4t6eAi7gClC56jOYnaDCBQRpqOc7ui+uRFKUEZfpujL6IgizuDmrgODInj2KYfJxAKiIisefQyIMTg0TKD5ys+laFMUJQfhuBq4e0awhPuNgIrBhYxMYAqxLgEQwuyLieCBLGbGWuALjQQi4gU5IsAAsri3A0uudLflueGCiJuBxrY8SZlYV6FvYkF8iKTErOyQxeHBKF4AAZqonokGA6CqFoUAFFoEB0E+oVQDQEDaGAuDkKgQXJU+uD+YFwWxRFUUxWFWH0j+24dHyAHmJVslMW4fwyOmNoILeuBuOOYyAlyDhdD5mUBUFIVhXl0VlrF6WqWxsXxYlalaAAboQADWSVsb12UDeFkXDdso0rRNYUIKF82YKlbx1EVpn8YEbjGLMdjCms4yNVy2acrBUT2OYPVZf1uWbQVUBjeie1xcF6CEOguBUJ6qW+eDAC2gPpN9OWDX9I1hYjeDAwdc2EMdDJncZkZ8W2owhIx7L9OC5HCpBfSzHC8QPV9fUoxt+XowDyMQ9zk0JVoSWHYty0ZbzqMc9tGPc6tP37UL+OnfI504W2QorNYH3ih9Q7-jJxEfSza2-RLOCjdLYsg+gYMQ1DMPw5jMts0N-2OzzrPrTjR0ndohOfsVZntGT1h1Q4j2TMeMljkM-Y9Z6hCoBAsW6eDYBbTg3BwAAroFsCY3z01C0tDtxwnScp2n2AZ7A2dkHncu4wrPtK0T2Ek7+hh8jdXT1cY-TmIe5FOFJ3wfbeLlhB9Yyx-Hidhcn6Cp0+Vc17nwM0KD4OQ9DJCw+gCMrSXs9QPPi9lsvOd11Ant497Wi+7xrbt6YWYXu9DEdh4aZh4EiZWV05F-DiH8CwSQHxaEIBAOAug2IPxKuZQwgJCIRA7KOScvJrSTA7lyM0sEiwyDCB4FwPUFT7GoLAgORgnBuBkuOdkY5e5Wm-h0NYVkEL1W5OYUOMJEisQyguchl0yr2BkoCYwM4xhjjiGEai+DcBrDiMOVw9k+iG1luzCusUBFtnZCEYEXQIhML5AzRMlF+xpgoveFS6ILbO05pjLRv5IiWA8MOUOkEGLWEZvIqc443CqKdmjSWANdr-QcaVOIhEXEWDcU9fonivD-Bjrw1SNjAmmwxitfmYAwnmWfpEM0QDog3nFBmYwIpugJOZsk6x7tjYaKlu7HJ7QnGsJ7gYgU3IRSoISbCOM+DlKPhSbU8W9Subu1dpokyKtfwRNafo-sQ4ylyKjgY-x61bFBNdrgLJTSf72RzMMRC7k3qmCHJZMwFNPrVPSIfMuC8K7nzILsjotgRRQn7gsTM-Z4hjGcmMNk-9royD5O86epc57lyXlnC+wNnmdELJCECA8P4-MMb-TqACrBAPBFcpIQA */
+  /** @xstate-layout N4IgpgJg5mDOIC5SzAQwE4GMAWA6ARgPaEAusJ6qADgMQDKAogCoD6AigKoMBKAmiwGEAMgEkGAOSYBtAAwBdRKCqFYASxKrCAO0UgAHogC0ANgCMAVlwAWAJzGATDIAcNmeYDM9zwBoQAT0QLAHZcYycnIKdTSNcndysAXwTfFAwcAmIyCmp6ZhZGAEFuAQAJfKZuEXEAcVkFJBBlNQ1tXQMEQytjS0cbKyCg0xdwpytzXwCEd2jcGxt3d1Gne273AaSUtCw8IlJySlpGViqRJhECoRYAMREhJh46Ot0m9U0dBvaTR1Cw0ysFpzmLxuCaIKxDXCmdw2cwyFamYyLKIbECpbYZPbZWgAIQA8rimHQKgUAAosAAiuPEDCeDReLXeoE+5iiuCC0Js9isK36phhoIQphkNlC4Ui0RczniphRaPSuyyBxoeIJRO4pIpVJppnqShUr1aHyMLNMbI5XJ5g35-kQZlFESiMSl4NlW3SqggABswDQmLjqtUhAxrrd7txaXrmm82oh4j17C47OYHE5jALHPZcOYuiNxXF3A5XWk8B7vb7-YHgzc7jwpDrnvqGTGEPYgiKvH1ls4gkDugLzBZcAWglygmE22ZjEX0aWfUxeCSqrV5A2o4amcbubM-vY5gsYQiggK21ZIcCZHDjD3wVPkqi3SWvT7CsUShHGo3o0apnEs64HDInj2KYfJxAKiIigOxh9DIgyptCMp3nKj5li+pR1rqH5roy+ixgMkLcjYCLmD2Ep2AKsS4BEMLsi4njuAO07uk+NBCLiBTkiwACyuLcDSK50p+664YKRG4LutjxPYXIXgO9gCiBcxUQ4V7TMsaw2EETF4AAZqonokGA6CqFoUAFFoEB0A+JlQDQEDaGAuDkKghlOQ+uB6QZRk2eZlnWaZ770l+G4dHyMhZuYLJtqmbh-DIVj9qebgjmMgJcg4XTaR5+mGcZpm+VZxY2W5xYldsNl2Q5uAmQAboQADWjnIdlXl5WZFmFeVpllekyE2QgtWEJgLlvHUgVCTh7RCsmsx2MKazjDaLZWE4sz2CRUTrVlnm5T5HX+VAPV4H1pk0EZ6CEOguBUJ6Lk6ZdAC2R0tbt+X7UV3XNSdUADVodXDQyY0CZGBqTYgowhHB7L9OCwHCgpfSzHC8QLdtOXeW9fkfYdO1GS9GO2fZWiOYNjXPbjbUFQd+NXRT-WDQDo3yON2HNkKKzWOt4rrf2QThZKDjmGjrV7VjXU4+jtOSxV52Xddt0kPd6BPc1dOY51ODFRTNP039Q0jdoQOYUFwntBD1hxYL-YIspUNC0h7meoQqAQDZXGXWAGvYNwcAAK4GbAR0VUTJN62TzVOy7bse17PuwP7ZBB6Zv3-QbWhG6uoPNoYfLGNYxjxcY-TmPMnhDBR3zrdmfJ2Ms2b25spWR67pnu+gnsPnHCeB99Z3oBdV03Xdj3Pc30ft7HfsB0nP0M2nGeCaz345wmZ6bbBrYeFYYwKV47jiV0wF-HEfwWEkd5aIQEBwLoyGZ02y+AvvEStsORdWotkwr6e7LJpyXbQSFDYLKCp9jUHvsFEShgnBuCoiOdkV5358k-kYNY4kGJ823utQWMJEgO1KrOCBpsjCmEzOEZMk4xhXjiGEcCMg85rDiAOEu8VhR4MbuiNW7Uxaa1MkQsGCB2QhGBDmHsCMkZeC8DA2EJFuzC1etwr2xU76Lyzt+SIlgPDMKtktIUIQrDI0igxSSK0G73lKlwqm2NnrfX4c2fMWYGIWB0ZMUc1hkb-B7PIgmVjxbPRDnY78pDIhmhPtEK8G1TDpmgqEIEKMvH4M4dLdW1MKaBJCho9BhcIgoIQIRIcV4LTrU0jDW8HD0iWPen47WXD0kiQcSI8cuS-4FLtt4ymVTeES1argAJqiH4hVIQYrMwwgjcgieKfsYkzBtMSekMercY6dynmQOpnxbAiihCXBY0kezxB3rov4lgxkqQygmFwWUFlQDbh3YsXdp62P6ZA9ZA5IQMVLrsreBzJikIWAfBwIEVrTHBPbJIQA */
   id: "search",
   initial: "bootstrap",
   context: ({ input }) => ({
@@ -90,10 +91,11 @@ export default searchMachineSetup.createMachine({
                   if (!context.queryClient) {
                     throw new Error("QueryClient is not set in context.")
                   }
+
                   return {
                     q: context.currentQuery,
                     queryClient: context.queryClient,
-                    filters: context.selectedFilters,
+                    filters: getFiltersForSearchRequest(context),
                     offset: context.searchOffset,
                     limit: context.searchPageSize,
                   }
@@ -123,7 +125,7 @@ export default searchMachineSetup.createMachine({
                   return {
                     q: context.currentQuery,
                     queryClient: context.queryClient,
-                    filters: context.selectedFilters,
+                    filters: getFiltersForSearchRequest(context),
                     facetLimit: context.facetLimit,
                   }
                 },
@@ -158,7 +160,7 @@ export default searchMachineSetup.createMachine({
               return {
                 q: context.currentQuery,
                 queryClient: context.queryClient,
-                filters: context.selectedFilters,
+                filters: getFiltersForSearchRequest(context),
                 offset: context.searchOffset,
                 limit: context.searchPageSize,
               }

--- a/lib/machines/search/useSearchMachineActor.tsx
+++ b/lib/machines/search/useSearchMachineActor.tsx
@@ -7,9 +7,9 @@ import { useSearchParams } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
 import { AnyEventObject, createActor } from "xstate"
 
-import { getFacetsForSearchRequest } from "@/components/pages/searchPageLayout/helper"
 import goConfig from "@/lib/config/goConfig"
 
+import { transformSearchParamsIntoFilters } from "./helpers"
 import searchMachine from "./search.machine"
 
 const searchActor = createActor(searchMachine, {
@@ -62,7 +62,7 @@ const useSearchMachineActor = () => {
     }
 
     const q = searchParams.get("q")
-    const filters = getFacetsForSearchRequest(searchParams as ReadonlyURLSearchParams)
+    const filters = transformSearchParamsIntoFilters(searchParams as ReadonlyURLSearchParams)
 
     if (!_.isEmpty(filters)) {
       actor.send({ type: "SET_INITIAL_FILTERS", filters })

--- a/lib/machines/search/useSearchMachineActor.tsx
+++ b/lib/machines/search/useSearchMachineActor.tsx
@@ -38,28 +38,6 @@ searchActor.on("filterToggled", (emittedEvent: AnyEventObject) => {
   window.history.pushState({}, "", url.href)
 })
 
-// Make sure the search query is removed from the URL when the search is cleared.
-// And the same goes for facets.
-searchActor.on("qDeleted", () => {
-  let urlShouldBeUpdated = false
-
-  const url = new URL(window.location.href)
-  if (url.searchParams.get("q")) {
-    url.searchParams.delete("q")
-    urlShouldBeUpdated = true
-  }
-
-  const facets = getFacetsForSearchRequest(url.searchParams as ReadonlyURLSearchParams)
-  for (const filter in facets) {
-    url.searchParams.delete(filter)
-    urlShouldBeUpdated = true
-  }
-
-  if (urlShouldBeUpdated) {
-    window.history.pushState({}, "", url.href)
-  }
-})
-
 /**
  *
  * This hook is referencing the searchActor from the search.machine.ts file.

--- a/lib/machines/search/useSearchMachineActor.tsx
+++ b/lib/machines/search/useSearchMachineActor.tsx
@@ -18,6 +18,8 @@ const searchActor = createActor(searchMachine, {
     searchPageSize: goConfig("search.item.limit"),
     facetLimit: goConfig("search.facet.limit"),
   },
+  // Uncomment this line to enable event debugging.
+  // inspect: debugEvents,
 }).start()
 
 // Administer search query params when filters are toggled.

--- a/lib/providers/ReactQueryProvider.tsx
+++ b/lib/providers/ReactQueryProvider.tsx
@@ -5,7 +5,16 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { useState } from "react"
 
 function ReactQueryProvider({ children }: React.PropsWithChildren) {
-  const [client] = useState(new QueryClient())
+  const [client] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          // TODO: Move this into config.
+          staleTime: 5 * 60 * 1000, // 5 mins
+        },
+      },
+    })
+  )
 
   return (
     <QueryClientProvider client={client}>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-130

#### Description

This PR adresses the behaviour that changed after the transition to use Xstate in searching/filtering.
Things being handled:
* The skeleton screen on load more
* The behaviour around deleting last character in the search field (which was actually working as intended, but I agree in an oddly manner 😆 )
* The weird issue about FBI sending one kind of facet names from service and expecting another as input (lix -> lixRange)
* Changing the way filters where toggled and detected as being active (that was not handled after the inital xstate introduction)
* Allowing the end user to type and filter while requests are ongoing
