### PR TITLE
fix: show ghost loading both when loading more results and initial results

### DIFF
--- a/components/pages/searchPageLayout/SearchPageLayout.tsx
+++ b/components/pages/searchPageLayout/SearchPageLayout.tsx
@@ -81,7 +81,7 @@ const SearchPageLayout = () => {
                     </motion.div>
                   )
               )}
-            {isLoadingMoreResults && <SearchResultsGhost />}
+            {(isLoadingMoreResults || isLoadingResults) && <SearchResultsGhost />}
           </div>
         </>
       ) : (


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-246

#### Description

Look in the title