### PR TITLE
fix: search machine to have a specific method for loading more results

### DIFF
--- a/lib/machines/search/search.machine.setup.ts
+++ b/lib/machines/search/search.machine.setup.ts
@@ -77,6 +77,18 @@ export default setup({
         event: {
           output: { search },
         },
+      }) => {
+        return {
+          hitcount: search.hitcount,
+          pages: [[...search.works]],
+        }
+      },
+    }),
+    addMoreDataInContext: assign({
+      searchData: ({
+        event: {
+          output: { search },
+        },
         context: { searchData },
       }) => {
         return {

--- a/lib/machines/search/search.machine.ts
+++ b/lib/machines/search/search.machine.ts
@@ -213,7 +213,7 @@ export default searchMachineSetup.createMachine({
               }
             },
             onDone: {
-              actions: ["setSearchDataInContext"],
+              actions: ["addMoreDataInContext"],
               target: "#search.idle",
             },
             onError: {},


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-286

#### Description

This PR introduces a fix to the search result page where search result dont get updated when clicking a tag on the material page