### PR TITLE
fix: remove await from prefetch functions in search page for improved perceived performance when loading search result page

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -12,8 +12,8 @@ const Page = async (props: { searchParams: Promise<{ q: string }> }) => {
   const { q } = searchParams
 
   const queryClient = getQueryClient()
-  await prefetchSearchResult(q, queryClient)
-  await prefetchSearchFacets(q, queryClient)
+  prefetchSearchResult(q, queryClient)
+  prefetchSearchFacets(q, queryClient)
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-287

#### Description

This PR makes the user go directly to search result page when making a search
