### PR TITLE
Solve "System.IO.IOException: No space left on device" error

### DIFF
--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -8,8 +8,6 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
           tool-cache: false
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-source.yml
+++ b/.github/workflows/publish-source.yml
@@ -5,6 +5,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
See if this solves our issue with Github action runner that is running out of space:
https://github.com/marketplace/actions/free-disk-space-ubuntu

#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-340

#### Description

It seems like using [Free Disk Space (Ubuntu) action
](https://github.com/marketplace/actions/free-disk-space-ubuntu) helps solving the Github Action runner "System.IO.IOException: No space left on device" error.
Error can be seen [here](https://github.com/danskernesdigitalebibliotek/dpl-go/actions/runs/12688155533).
[This](https://github.com/danskernesdigitalebibliotek/dpl-go/actions/runs/12690334230) is a succesful run after adding the Free Disk Space action.

