### PR TITLE
Bypass graphql cache in development

### DIFF
--- a/lib/getQueryClient.ts
+++ b/lib/getQueryClient.ts
@@ -1,13 +1,14 @@
 import { QueryClient } from "@tanstack/react-query"
 import { cache } from "react"
 
+import { getQueryClientStaleTime } from "./helpers/graphql"
+
 const getQueryClient = cache(
   () =>
     new QueryClient({
       defaultOptions: {
         queries: {
-          // TODO: Move this into config.
-          staleTime: 5 * 60 * 1000, // 5 mins
+          staleTime: getQueryClientStaleTime(),
         },
       },
     })

--- a/lib/helpers/graphql.ts
+++ b/lib/helpers/graphql.ts
@@ -1,0 +1,5 @@
+import { getEnvironment } from "./helper.env"
+
+// If production set stale time to 1 minute, otherwise set to 0.
+// Which means no caching in development.
+export const getQueryClientStaleTime = () => (getEnvironment() === "production" ? 1 * 60 * 1000 : 0)

--- a/lib/providers/ReactQueryProvider.tsx
+++ b/lib/providers/ReactQueryProvider.tsx
@@ -4,13 +4,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { useState } from "react"
 
+import { getQueryClientStaleTime } from "../helpers/graphql"
+
 function ReactQueryProvider({ children }: React.PropsWithChildren) {
   const [client] = useState(
     new QueryClient({
       defaultOptions: {
         queries: {
-          // TODO: Move this into config.
-          staleTime: 5 * 60 * 1000, // 5 mins
+          staleTime: getQueryClientStaleTime(),
         },
       },
     })


### PR DESCRIPTION
Bypass graphql cache in development
And set the staleTime to 1 minute in production because we, in dpl-cms content context, will rely on the caching system in NextJs
