### PR TITLE
Add force-dynamic to routes that always need to be dynamic

### DIFF
--- a/app/auth/login/unilogin/route.ts
+++ b/app/auth/login/unilogin/route.ts
@@ -26,3 +26,5 @@ export async function GET() {
   await session.save()
   return Response.redirect(redirectTo)
 }
+
+export const dynamic = "force-dynamic"

--- a/app/auth/logout/route.ts
+++ b/app/auth/logout/route.ts
@@ -33,3 +33,5 @@ export async function GET() {
 
   return Response.redirect(`${appUrl.toString()}?reload-session=true`)
 }
+
+export const dynamic = "force-dynamic"


### PR DESCRIPTION
These kind of routes are used for authorisation and session handling and should never be statically generated.
