### PR TITLE
Prevent endless node reloading in Lagoon deployment?

### DIFF
--- a/lagoon/start.sh
+++ b/lagoon/start.sh
@@ -31,7 +31,5 @@ export NEXT_PUBLIC_GRAPHQL_SCHEMA_ENDPOINT_DPL_CMS="$cms_url/graphql"
 
 # Go to the app directory if it doesn't exist then never mind.
 cd /app || exit 1
-# TODO: Remember to adjust the following line before deploying to production.
-# Using `yarn start:with-server-source-maps` is probably adding a performance overhead.
-yarn build && yarn start:with-server-source-maps
+yarn build && yarn start
 exit 0

--- a/lib/config/dpl-cms/dplCmsConfig.ts
+++ b/lib/config/dpl-cms/dplCmsConfig.ts
@@ -40,7 +40,7 @@ export const getDplCmsUniloginConfig = async () => {
       ? process.env.UNILOGIN_CLIENT_ID
       : (config?.unilogin?.unilogin_api_client_id ?? null),
     clientSecret: process.env.UNILOGIN_CLIENT_SECRET
-      ? process.env.UNILOGIN_WELLKNOWN_URL
+      ? process.env.UNILOGIN_CLIENT_SECRET
       : (config?.unilogin?.unilogin_api_client_secret ?? null),
     apiData: config?.unilogin ?? null,
   }


### PR DESCRIPTION

#### Description

We are again running into that the kubernetes deployment
is impatient and restarts node again and again.
Maybe it helps not trying to create source maps.
Let's see...
