### PR TITLE
Providing Adgangslogin url to Go + fixing dpl-cms options type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,4 @@ UNILOGIN_CLIENT_ID=https://stg.ereolengo.itkdev.dk/
 UNILOGIN_CLIENT_SECRET=XXX
 GO_SESSION_SECRET=XXX
 
-NEXT_PUBLIC_APP_URL=https://localhost:3000
+NEXT_PUBLIC_APP_URL=https://dapple-cms.docker:3000

--- a/app/auth/callback/adgangsplatformen/loadUserToken.ts
+++ b/app/auth/callback/adgangsplatformen/loadUserToken.ts
@@ -20,7 +20,9 @@ const loadUserToken = async () => {
   const data = await queryClient.fetchQuery<GetAdgangsplatformenUserTokenQuery>({
     queryKey: useGetAdgangsplatformenUserTokenQuery.getKey(),
     queryFn: useGetAdgangsplatformenUserTokenQuery.fetcher(undefined, {
-      Cookie: `${sessionCookie.name}=${sessionCookie.value}`,
+      headers: {
+        Cookie: `${sessionCookie.name}=${sessionCookie.value}`,
+      },
     }),
     initialData: {},
     staleTime: 0,

--- a/codegen.ts
+++ b/codegen.ts
@@ -1,8 +1,7 @@
 import type { CodegenConfig } from "@graphql-codegen/cli"
+import { loadEnvConfig } from "@next/env"
 
 import goConfig from "./lib/config/goConfig"
-
-const { loadEnvConfig } = require("@next/env")
 
 loadEnvConfig(process.cwd())
 

--- a/codegen.ts
+++ b/codegen.ts
@@ -34,6 +34,8 @@ const config: CodegenConfig = {
         fetcher: "@/lib/graphql/fetchers/dpl-cms.fetcher#fetcher",
       },
       hooks: {
+        // Correcting the codegen output.
+        // First off, we correct the type of the options for the fetcher.
         afterOneFileWrite: ["yarn post-process-dpl-cms-graphql", "yarn eslint --fix"],
       },
     },

--- a/codegen.ts
+++ b/codegen.ts
@@ -34,7 +34,7 @@ const config: CodegenConfig = {
         fetcher: "@/lib/graphql/fetchers/dpl-cms.fetcher#fetcher",
       },
       hooks: {
-        afterOneFileWrite: ["yarn eslint --fix"],
+        afterOneFileWrite: ["yarn post-process-dpl-cms-graphql", "yarn eslint --fix"],
       },
     },
     // "lib/graphql/generated/dpl-cms/graphql.schema.json": {

--- a/components/global/header/ProfileButton.tsx
+++ b/components/global/header/ProfileButton.tsx
@@ -14,6 +14,7 @@ import {
   SheetTrigger,
 } from "@/components/shared/sheet/Sheet"
 import useSession from "@/hooks/useSession"
+import useGetDplCmsLoginUrls from "@/lib/config/dpl-cms/useGetDplCmsLoginUrls"
 
 const HeaderButton = ({
   onClick,
@@ -31,6 +32,8 @@ const HeaderButton = ({
 function ProfileButton() {
   const { session, isLoading } = useSession()
   const router = useRouter()
+  const { adgangsplatformen: adgangsplatformenLoginUrl } = useGetDplCmsLoginUrls()
+
   if (isLoading) {
     return (
       <>
@@ -65,28 +68,30 @@ function ProfileButton() {
                 </Button>
               </div>
             </div>
-            <hr className="border-foreground mx-auto w-full opacity-10 md:w-full" />
-            <div className="bg-background-overlay py-space-y flex min-h-[300px] flex-col items-center justify-center rounded-sm">
-              <div className="mb-4">
-                <Icon name="adgangsplatformen" />
-              </div>
-              <SheetDescription className="text-typo-heading-4 text-foreground">
-                Login via Biblotekernes
-              </SheetDescription>
-              <SheetDescription className="text-typo-heading-4 text-foreground mb-4">
-                fælles loginside
-              </SheetDescription>
-              <div>
-                <Button
-                  theme="primary"
-                  onClick={() =>
-                    router.push(`https://dapple-cms.docker/login?current-path=/go-login`)
-                  }
-                  ariaLabel="Log ind med Adgangsplatformen">
-                  LOG IND
-                </Button>
-              </div>
-            </div>
+            {adgangsplatformenLoginUrl && (
+              <>
+                <hr className="border-foreground mx-auto w-full opacity-10 md:w-full" />
+                <div className="bg-background-overlay py-space-y flex min-h-[300px] flex-col items-center justify-center rounded-sm">
+                  <div className="mb-4">
+                    <Icon name="adgangsplatformen" />
+                  </div>
+                  <SheetDescription className="text-typo-heading-4 text-foreground">
+                    Login via Biblotekernes
+                  </SheetDescription>
+                  <SheetDescription className="text-typo-heading-4 text-foreground mb-4">
+                    fælles loginside
+                  </SheetDescription>
+                  <div>
+                    <Button
+                      theme="primary"
+                      onClick={() => router.push(adgangsplatformenLoginUrl)}
+                      ariaLabel="Log ind med Adgangsplatformen">
+                      LOG IND
+                    </Button>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </SheetContent>
       </Sheet>

--- a/components/global/header/ProfileButton.tsx
+++ b/components/global/header/ProfileButton.tsx
@@ -55,8 +55,8 @@ function ProfileButton() {
             <SheetTitle className="text-typo-heading-3">Log ind</SheetTitle>
           </SheetHeader>
           <div className="flex h-full flex-col justify-center space-y-8">
-            <div className="bg-background-overlay py-space-y flex h-[300px] flex-col items-center justify-center rounded-sm">
-              <SheetDescription className="text-typo-heading-4 text-foreground mb-4">
+            <div className="bg-background-overlay flex min-h-[300px] flex-col items-center justify-center rounded-sm p-8">
+              <SheetDescription className="text-typo-heading-4 text-foreground mb-4 text-center">
                 Log ind med UNI•Login
               </SheetDescription>
               <div>
@@ -71,15 +71,12 @@ function ProfileButton() {
             {adgangsplatformenLoginUrl && (
               <>
                 <hr className="border-foreground mx-auto w-full opacity-10 md:w-full" />
-                <div className="bg-background-overlay py-space-y flex h-[300px] flex-col items-center justify-center rounded-sm">
+                <div className="bg-background-overlay flex min-h-[300px] flex-col items-center justify-center rounded-sm p-8">
                   <div className="mb-4">
                     <Icon name="adgangsplatformen" />
                   </div>
-                  <SheetDescription className="text-typo-heading-4 text-foreground">
-                    Login via Biblotekernes
-                  </SheetDescription>
-                  <SheetDescription className="text-typo-heading-4 text-foreground mb-4">
-                    fælles loginside
+                  <SheetDescription className="text-typo-heading-4 text-foreground mb-4 text-center">
+                    Login via Biblotekernes fælles loginside
                   </SheetDescription>
                   <div>
                     <Button

--- a/components/global/header/ProfileButton.tsx
+++ b/components/global/header/ProfileButton.tsx
@@ -55,7 +55,7 @@ function ProfileButton() {
             <SheetTitle className="text-typo-heading-3">Log ind</SheetTitle>
           </SheetHeader>
           <div className="flex h-full flex-col justify-center space-y-8">
-            <div className="bg-background-overlay py-space-y flex min-h-[300px] flex-col items-center justify-center rounded-sm">
+            <div className="bg-background-overlay py-space-y flex h-[300px] flex-col items-center justify-center rounded-sm">
               <SheetDescription className="text-typo-heading-4 text-foreground mb-4">
                 Log ind med UNI•Login
               </SheetDescription>
@@ -71,7 +71,7 @@ function ProfileButton() {
             {adgangsplatformenLoginUrl && (
               <>
                 <hr className="border-foreground mx-auto w-full opacity-10 md:w-full" />
-                <div className="bg-background-overlay py-space-y flex min-h-[300px] flex-col items-center justify-center rounded-sm">
+                <div className="bg-background-overlay py-space-y flex h-[300px] flex-col items-center justify-center rounded-sm">
                   <div className="mb-4">
                     <Icon name="adgangsplatformen" />
                   </div>

--- a/graphql-codegen-scripts/post-process-dpl-cms-graphql.ts
+++ b/graphql-codegen-scripts/post-process-dpl-cms-graphql.ts
@@ -12,7 +12,7 @@ if (!pathToGeneratedFile) {
 replaceInFile({
   files: pathToGeneratedFile,
   from: /RequestInit\['headers'\]/g,
-  to: "RequestInit",
+  to: "RequestInit & { next?: NextFetchRequestConfig }",
 })
   .then((results: unknown) => {
     // eslint-disable-next-line no-console

--- a/graphql-codegen-scripts/post-process-dpl-cms-graphql.ts
+++ b/graphql-codegen-scripts/post-process-dpl-cms-graphql.ts
@@ -1,0 +1,25 @@
+import { replaceInFile } from "replace-in-file"
+
+const args: string[] = process.argv.slice(2)
+const pathToGeneratedFile = args[0] ?? null
+
+if (!pathToGeneratedFile) {
+  throw new Error("Missing path to generated file!")
+}
+
+// Replace RequestInit['headers'] with RequestInit since
+// we need to be able to inject next options in the fetcher:
+replaceInFile({
+  files: pathToGeneratedFile,
+  from: /RequestInit\['headers'\]/g,
+  to: "RequestInit",
+})
+  .then((results: unknown) => {
+    // eslint-disable-next-line no-console
+    console.log("Replacement results:", results)
+  })
+  .catch((error: unknown) => {
+    console.error("Error occurred:", error)
+  })
+
+export {}

--- a/lib/config/dpl-cms/dplCmsConfig.ts
+++ b/lib/config/dpl-cms/dplCmsConfig.ts
@@ -1,19 +1,11 @@
-import { fetcher } from "@/lib/graphql/fetchers/dpl-cms.fetcher"
-import {
-  GetDplCmsConfigurationDocument,
-  GetDplCmsConfigurationQuery,
-  GetDplCmsConfigurationQueryVariables,
-} from "@/lib/graphql/generated/dpl-cms/graphql"
+import { useGetDplCmsConfigurationQuery } from "@/lib/graphql/generated/dpl-cms/graphql"
 
 const queryDplCmsConfig = async () => {
-  const { dplConfiguration } = await fetcher<
-    GetDplCmsConfigurationQuery,
-    GetDplCmsConfigurationQueryVariables
-  >(GetDplCmsConfigurationDocument, undefined, {
+  const { goConfiguration } = await useGetDplCmsConfigurationQuery.fetcher(undefined, {
     next: { revalidate: 30 },
   })()
 
-  return dplConfiguration ?? null
+  return goConfiguration ?? null
 }
 
 export const getDplCmsUniloginConfig = async () => {

--- a/lib/config/dpl-cms/useGetDplCmsLoginUrls.ts
+++ b/lib/config/dpl-cms/useGetDplCmsLoginUrls.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react"
+
+import { GetLoginUrlsQuery, useGetLoginUrlsQuery } from "@/lib/graphql/generated/dpl-cms/graphql"
+
+const queryDplCmsConfig = async () => {
+  const { goConfiguration } = await useGetLoginUrlsQuery.fetcher(undefined, {
+    next: { revalidate: 30 },
+  })()
+
+  return goConfiguration ?? null
+}
+
+export default function useGetDplCmsLoginUrls() {
+  const [config, setConfig] = useState<GetLoginUrlsQuery["goConfiguration"] | undefined | null>(
+    undefined
+  )
+
+  useEffect(() => {
+    if (config !== undefined) {
+      return
+    }
+
+    const fetchData = async () => {
+      const fetchedConfig = await queryDplCmsConfig()
+      if (fetchedConfig !== null) {
+        setConfig(fetchedConfig ?? null)
+      }
+    }
+    fetchData()
+  }, [config])
+
+  return { adgangsplatformen: config?.loginUrls?.adgangsplatformen ?? null }
+}

--- a/lib/graphql/fetchers/dpl-cms.fetcher.ts
+++ b/lib/graphql/fetchers/dpl-cms.fetcher.ts
@@ -18,7 +18,7 @@ const getHeaders = (headers: RequestInit["headers"] | undefined) => {
 export function fetcher<TData, TVariables>(
   query: string,
   variables?: TVariables,
-  options?: RequestInit
+  options?: RequestInit & { next?: NextFetchRequestConfig }
 ) {
   const dplCmsGraphqlEndpoint = process.env.NEXT_PUBLIC_GRAPHQL_SCHEMA_ENDPOINT_DPL_CMS
   const dplCmsGraphqlBasicToken = process.env.NEXT_PUBLIC_GRAPHQL_BASIC_TOKEN_DPL_CMS
@@ -30,8 +30,7 @@ export function fetcher<TData, TVariables>(
   if (!dplCmsGraphqlBasicToken) {
     throw new Error("Missing DPL CMS GraphQL basic token")
   }
-  const { next, ...restOptions } = options || {}
-  const headers = restOptions as RequestInit["headers"]
+  const { next, headers } = options || {}
 
   return async (): Promise<TData> => {
     const res = await fetch(dplCmsGraphqlEndpoint, {
@@ -51,7 +50,7 @@ export function fetcher<TData, TVariables>(
     // TODO: Remove console logs when we are more confident
     // in dpl-cms fetching and caching of data.
     // eslint-disable-next-line no-console
-    console.log({ dplConfiguration: json?.data?.dplConfiguration })
+    console.log({ goConfiguration: json?.data?.goConfiguration })
     // TODO: Remove console logs when we are more confident
     // in dpl-cms fetching and caching of data.
     // eslint-disable-next-line no-console

--- a/lib/graphql/fetchers/dpl-cms.fetcher.ts
+++ b/lib/graphql/fetchers/dpl-cms.fetcher.ts
@@ -1,7 +1,3 @@
-type TFetcherOptions = (RequestInit | RequestInit["headers"]) & {
-  next?: NextFetchRequestConfig
-}
-
 const getHeaders = (headers: RequestInit["headers"] | undefined) => {
   const contentTypeHeader = {
     "Content-Type": "application/json",
@@ -22,7 +18,7 @@ const getHeaders = (headers: RequestInit["headers"] | undefined) => {
 export function fetcher<TData, TVariables>(
   query: string,
   variables?: TVariables,
-  options?: TFetcherOptions
+  options?: RequestInit
 ) {
   const dplCmsGraphqlEndpoint = process.env.NEXT_PUBLIC_GRAPHQL_SCHEMA_ENDPOINT_DPL_CMS
   const dplCmsGraphqlBasicToken = process.env.NEXT_PUBLIC_GRAPHQL_BASIC_TOKEN_DPL_CMS

--- a/lib/graphql/generated/dpl-cms/graphql.tsx
+++ b/lib/graphql/generated/dpl-cms/graphql.tsx
@@ -188,15 +188,15 @@ export type MediaAudio = MediaInterface & {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
   /** Audio file */
   mediaAudioFile: File;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -209,22 +209,22 @@ export type MediaDocument = MediaInterface & {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
-  /** File */
+  /** Fil */
   mediaFile: File;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
 /** Entity type media. */
 export type MediaImage = MediaInterface & {
   __typename?: 'MediaImage';
-  /** Used for public credit and copyright information. Will usually be displayed along with the media. */
+  /** Bruges til fotokreditering og info om copyright. Vises som regel ved siden af billedet. */
   byline?: Maybe<Scalars['String']['output']>;
   /** The time the media item was last edited. */
   changed: DateTime;
@@ -232,20 +232,21 @@ export type MediaImage = MediaInterface & {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
   /**
-   * You can set a focal point, by clicking on the preview on the image, moving the
-   * white target.<br /><br />By setting a focal point, you tell the system which
-   * part of the image to keep in focus when it gets cropped.<br /><br />Use the
-   * "preview" function, to see how your image will be cropped across image styles.
+   * Du kan indstille et fokuspunkt ved at klikke på forhåndsvisningen af
+   * billedet og flytte det hvide mål.<br /><br />Ved at indstille et fokuspunkt
+   * fortæller du systemet, hvilken del af billedet der skal være i fokus, når
+   * det beskæres.<br /><br />Brug funktionen "forhåndsvisning" til at se,
+   * hvordan dit billede vil blive beskåret på tværs af billedstil.
    */
   mediaImage: Image;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -257,13 +258,13 @@ export type MediaInterface = {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -279,15 +280,15 @@ export type MediaVideo = MediaInterface & {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
-  /** Remote video URL */
+  /** URL til video */
   mediaOembedVideo: Scalars['String']['output'];
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -300,15 +301,15 @@ export type MediaVideotool = MediaInterface & {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
   /** VideoTool URL */
   mediaVideotool: Scalars['String']['output'];
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -319,19 +320,19 @@ export type Mutation = {
   _: Scalars['Boolean']['output'];
 };
 
-/** Use articles for news-worthy content, that does not get updated regularly. */
+/** Brug artikler til nyhedspræget indhold med en begrænset levetid. */
 export type NodeArticle = NodeInterface & {
   __typename?: 'NodeArticle';
-  /** Branch */
+  /** Bibliotek */
   branch?: Maybe<NodeUnion>;
   /**
-   * Please provide a canonical URL if this content has been duplicated from other
-   * websites. This helps signal to search engines that the preferred source of
-   * this content is the specified canonical URL, preventing potential duplicate
-   * content issues and ensuring proper attribution to the original source.
+   * Oplys en canonical URL hvis indholdet i artiklen er kopieret fra en anden
+   * hjemmeside (fx kopieret fra et andet biblioteks hjemmeside). Dette hjælper
+   * med at signalere til søgemaskiner at kilden til indholdet er den
+   * specificerede side, og sikrer at den originale kilde krediteres.
    */
   canonicalUrl?: Maybe<Link>;
-  /** Categories */
+  /** Kategorier */
   categories?: Maybe<TermUnion>;
   /** Tidspunktet hvor indholdselementet sidst blev redigeret. */
   changed: DateTime;
@@ -339,9 +340,9 @@ export type NodeArticle = NodeInterface & {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
-  /** Override author */
+  /** Overskriv forfatter */
   overrideAuthor?: Maybe<Scalars['String']['output']>;
   /** Paragraphs */
   paragraphs?: Maybe<Array<ParagraphUnion>>;
@@ -352,27 +353,26 @@ export type NodeArticle = NodeInterface & {
   /** Publication date */
   publicationDate: DateTime;
   /**
-   * By default, the author is set to the Drupal user that owns the content.<br
-   * /><br />If you want to override this, with a manual text, you can check this.
+   * Som standard er forfatteren sat til den Drupal-bruger, der ejer indholdet.<br
+   * /><br />Hvis du ønsker at tilsidesætte dette med din egen tekst, kan du
    */
   showOverrideAuthor?: Maybe<Scalars['Boolean']['output']>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Klæbrig */
   sticky: Scalars['Boolean']['output'];
-  /** Subtitle */
+  /** Manchet */
   subtitle?: Maybe<Scalars['String']['output']>;
   /** Tags */
   tags?: Maybe<Array<TermUnion>>;
   /**
-   * The teaser fields are used for the card of display.<br />If no image has been
-   * selected, the text will be shown instead:<br /><br /><img
-   * src="/themes/custom/novel/images/teaser-text-image.jpg" /><br /><br /><hr/>
+   * Teaserfelterne bruges til cards som blikfang for indholdet. Hvis der ikke er
+   * valgt et teaserbillede, vil teksten vises i stedet.
    */
   teaserImage?: Maybe<MediaUnion>;
-  /** Teaser text */
+  /** Teasertekst */
   teaserText?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Titel */
   title: Scalars['String']['output'];
 };
 
@@ -387,7 +387,7 @@ export type NodeGoArticle = NodeInterface & {
   goArticleImage?: Maybe<MediaUnion>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
   /** Override author */
   overrideAuthor?: Maybe<Scalars['String']['output']>;
@@ -404,7 +404,7 @@ export type NodeGoArticle = NodeInterface & {
    * /><br />If you want to override this, with a manual text, you can check this.
    */
   showOverrideAuthor?: Maybe<Scalars['Boolean']['output']>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Klæbrig */
   sticky: Scalars['Boolean']['output'];
@@ -418,7 +418,7 @@ export type NodeGoArticle = NodeInterface & {
   teaserImage: MediaUnion;
   /** Teaser text */
   teaserText?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Titel */
   title: Scalars['String']['output'];
 };
 
@@ -428,8 +428,6 @@ export type NodeGoArticle = NodeInterface & {
  */
 export type NodeGoCategory = NodeInterface & {
   __typename?: 'NodeGoCategory';
-  /** Category menu color */
-  categoryMenuColor: Color;
   /** The category image will be shown in the category menu as part of this category's menu element. */
   categoryMenuImage: MediaUnion;
   /** The category sound will be able to be played in the category menu as part of this category's menu element. */
@@ -440,9 +438,11 @@ export type NodeGoCategory = NodeInterface & {
   changed: DateTime;
   /** The date and time that the content was created. */
   created: DateTime;
+  /** Category menu color */
+  goColor?: Maybe<Scalars['String']['output']>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
   /** Paragraphs */
   paragraphs?: Maybe<Array<ParagraphUnion>>;
@@ -452,11 +452,11 @@ export type NodeGoCategory = NodeInterface & {
   promote: Scalars['Boolean']['output'];
   /** Publication date */
   publicationDate: DateTime;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Klæbrig */
   sticky: Scalars['Boolean']['output'];
-  /** Title */
+  /** Titel */
   title: Scalars['String']['output'];
 };
 
@@ -473,7 +473,7 @@ export type NodeGoPage = NodeInterface & {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
   /** Paragraphs */
   paragraphs?: Maybe<Array<ParagraphUnion>>;
@@ -483,11 +483,11 @@ export type NodeGoPage = NodeInterface & {
   promote: Scalars['Boolean']['output'];
   /** Publication date */
   publicationDate: DateTime;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Klæbrig */
   sticky: Scalars['Boolean']['output'];
-  /** Title */
+  /** Titel */
   title: Scalars['String']['output'];
 };
 
@@ -499,17 +499,17 @@ export type NodeInterface = {
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Language */
+  /** Sprog */
   langcode: Language;
   /** Alternativ URL */
   path: Scalars['String']['output'];
   /** Forfremmet til forside */
   promote: Scalars['Boolean']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Klæbrig */
   sticky: Scalars['Boolean']['output'];
-  /** Title */
+  /** Titel */
   title: Scalars['String']['output'];
 };
 
@@ -519,9 +519,9 @@ export type NodeUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPag
 /** Entity type paragraph. */
 export type ParagraphAccordion = ParagraphInterface & {
   __typename?: 'ParagraphAccordion';
-  /** Accordion description */
+  /** Accordion beskrivelse */
   accordionDescription?: Maybe<Text>;
-  /** Accordion title */
+  /** Accordion titel */
   accordionTitle: Text;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -529,7 +529,7 @@ export type ParagraphAccordion = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -548,13 +548,13 @@ export type ParagraphBanner = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Underlined title */
   underlinedTitle?: Maybe<Text>;
 };
 
-/** Automatically display all content that is referencing your chosen breadcrumb item. */
+/** Vis automatisk alt indhold, som refererer til dit valgte brødkrumme element. */
 export type ParagraphBreadcrumbChildren = ParagraphInterface & {
   __typename?: 'ParagraphBreadcrumbChildren';
   /** The time that the Paragraph was created. */
@@ -563,7 +563,7 @@ export type ParagraphBreadcrumbChildren = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -574,13 +574,13 @@ export type ParagraphCardGridAutomatic = ParagraphInterface & {
   created: DateTime;
   /** If nothing is selected, all will be chosen. */
   filterBranches?: Maybe<Array<NodeUnion>>;
-  /** Filter by categories */
+  /** Filter efter kategorier */
   filterCategories?: Maybe<Array<TermUnion>>;
   /** Condition type */
   filterCondType: Scalars['String']['output'];
   /** If nothing is selected, all will be chosen. */
   filterContentTypes?: Maybe<Array<Scalars['String']['output']>>;
-  /** Filter by tags */
+  /** Filter efter tags */
   filterTags?: Maybe<Array<TermUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
@@ -588,9 +588,9 @@ export type ParagraphCardGridAutomatic = ParagraphInterface & {
   langcode: Language;
   /** More link */
   moreLink?: Maybe<Link>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
-  /** Title */
+  /** Titel */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -599,7 +599,7 @@ export type ParagraphCardGridManual = ParagraphInterface & {
   __typename?: 'ParagraphCardGridManual';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Content */
+  /** Indhold */
   gridContent?: Maybe<Array<ParagraphCardGridManualGridContentUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
@@ -607,19 +607,19 @@ export type ParagraphCardGridManual = ParagraphInterface & {
   langcode: Language;
   /** More link */
   moreLink?: Maybe<Link>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
-  /** Title */
+  /** Overskrift */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** Content */
+/** Indhold */
 export type ParagraphCardGridManualGridContentUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage;
 
 /** Entity type paragraph. */
 export type ParagraphContentSlider = ParagraphInterface & {
   __typename?: 'ParagraphContentSlider';
-  /** Contents */
+  /** Indhold */
   contentReferences?: Maybe<Array<ParagraphContentSliderContentReferencesUnion>>;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -627,7 +627,7 @@ export type ParagraphContentSlider = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** deprecated */
   title?: Maybe<Scalars['String']['output']>;
@@ -654,7 +654,7 @@ export type ParagraphContentSliderAutomatic = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** deprecated */
   title?: Maybe<Scalars['String']['output']>;
@@ -662,21 +662,21 @@ export type ParagraphContentSliderAutomatic = ParagraphInterface & {
   underlinedTitle?: Maybe<Text>;
 };
 
-/** Contents */
+/** Indhold */
 export type ParagraphContentSliderContentReferencesUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage;
 
-/** This paragraph displays a generated a list of events, based on specified filters for tags, categories and branches.  */
+/** Denne paragraph viser en liste af arrangementer filtreret på kategori, tags og filialer. */
 export type ParagraphFilteredEventList = ParagraphInterface & {
   __typename?: 'ParagraphFilteredEventList';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** If nothing is selected, all will be chosen. */
+  /** Tilføj enhver forgrening, du vil inkludere */
   filterBranches?: Maybe<Array<NodeUnion>>;
-  /** Add a category you want to include */
+  /** Tilføj en kategori, du vil inkludere */
   filterCategories?: Maybe<Array<TermUnion>>;
   /** Condition type */
   filterCondType: Scalars['String']['output'];
-  /** Add a tag you want to include */
+  /** Tilføj et tag, du vil inkludere */
   filterTags?: Maybe<Array<TermUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
@@ -688,10 +688,33 @@ export type ParagraphFilteredEventList = ParagraphInterface & {
    * enough results based on your selected filters.
    */
   maxItemAmount: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
-  /** Title */
+  /** Titel */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/**
+ * This link paragraph is used for links in GO, as it requires additional fields
+ * such as aria-label and ‘Open link in new window.’ These fields could not be
+ * exported in GraphQL when using a Linkit widget.
+ */
+export type ParagraphGoLink = ParagraphInterface & {
+  __typename?: 'ParagraphGoLink';
+  /** Aria Label */
+  ariaLabel?: Maybe<Scalars['String']['output']>;
+  /** The time that the Paragraph was created. */
+  created: DateTime;
+  /** The Universally Unique IDentifier (UUID). */
+  id: Scalars['ID']['output'];
+  /** The paragraphs entity language code. */
+  langcode: Language;
+  /** Link */
+  link: Array<Link>;
+  /** Publiceret */
+  status: Scalars['Boolean']['output'];
+  /** Open link in a new window */
+  targetBlank?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Entity type paragraph. */
@@ -700,18 +723,18 @@ export type ParagraphGoLinkbox = ParagraphInterface & {
   /** The time that the Paragraph was created. */
   created: DateTime;
   /** Color */
-  goColor?: Maybe<Color>;
+  goColor?: Maybe<Scalars['String']['output']>;
   /** Description */
   goDescription: Scalars['String']['output'];
   /** Image */
   goImage?: Maybe<MediaUnion>;
-  /** LInk */
-  goLink: Link;
+  /** Link */
+  goLink: ParagraphUnion;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Title */
   title: Scalars['String']['output'];
@@ -736,7 +759,7 @@ export type ParagraphGoMaterialSliderAutomatic = ParagraphInterface & {
   langcode: Language;
   /** Amount of materials */
   sliderAmountOfMaterials: Scalars['Int']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Title */
   title?: Maybe<Scalars['String']['output']>;
@@ -760,7 +783,7 @@ export type ParagraphGoMaterialSliderManual = ParagraphInterface & {
    * if it is available.<br />Example work ID: work-of:870970-basis:136336282
    */
   materialSliderWorkIds: Array<WorkId>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Title */
   title?: Maybe<Scalars['String']['output']>;
@@ -777,7 +800,7 @@ export type ParagraphGoVideo = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Title */
   title: Scalars['String']['output'];
@@ -809,7 +832,7 @@ export type ParagraphGoVideoBundleAutomatic = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** VideoTool URL. Example: https://media.videotool.dk/?vn=557_2023103014511477700668916683 */
   url?: Maybe<Scalars['String']['output']>;
@@ -833,7 +856,7 @@ export type ParagraphGoVideoBundleManual = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** VideoTool URL. Example: https://media.videotool.dk/?vn=557_2023103014511477700668916683 */
   url?: Maybe<Scalars['String']['output']>;
@@ -853,35 +876,35 @@ export type ParagraphInterface = {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
-/** This paragraph will show a list of events that are manually selected. */
+/** Dette afsnit vil vise en liste over arrangementer, der er manuelt valgt. */
 export type ParagraphManualEventList = ParagraphInterface & {
   __typename?: 'ParagraphManualEventList';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Events */
+  /** Arrangementer */
   events?: Maybe<Array<UnsupportedType>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
-  /** Title */
+  /** Titel */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** A grid representation of recommended materials, based on a CQL search string.  */
+/** En visning af fremhævede værker, baseret på en CQL søgestreng. */
 export type ParagraphMaterialGridAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphMaterialGridAutomatic';
   /**
-   * Determines the amount of materials that will be shown, based on the CQL
-   * string. <br /><br />Obs: If for example a CQL string has 11 results, and an
-   * editor chooses 12. The list will display 8 instead of 11, since the grid
-   * should be able to increment by 4.
+   * Bestemmer mængden af materialer, der vil blive vist, baseret på
+   * CQL-strengen. <br /><br />Obs: Hvis for eksempel en CQL-streng har 11
+   * resultater, og en redaktør vælger 12. Listen vil vise 8 i stedet for 11, da
+   * gitteret skal kunne øges med 4.
    */
   amountOfMaterials: Scalars['Int']['output'];
   /** The time that the Paragraph was created. */
@@ -892,13 +915,13 @@ export type ParagraphMaterialGridAutomatic = ParagraphInterface & {
   langcode: Language;
   /** This is the optional description for the material grid. <br />Leave blank if you do not want a description. */
   materialGridDescription?: Maybe<Scalars['String']['output']>;
-  /** The title for the material grid. Leave this blank if you do not want a title.  */
+  /** Titel på materialekomponenten. Efterlad dette felt blankt, hvis du ikke vil give den en overskrift. */
   materialGridTitle?: Maybe<Scalars['String']['output']>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
-/** A grid displaying a list of recommended materials selected manually. */
+/** En komponent som viser en liste af manuelt udvalgte værker. */
 export type ParagraphMaterialGridManual = ParagraphInterface & {
   __typename?: 'ParagraphMaterialGridManual';
   /** The time that the Paragraph was created. */
@@ -909,16 +932,16 @@ export type ParagraphMaterialGridManual = ParagraphInterface & {
   langcode: Language;
   /** This is the optional description for the material grid. <br />Leave blank if you do not want a description. */
   materialGridDescription?: Maybe<Scalars['String']['output']>;
-  /** The title for the material grid. Leave this blank if you do not want a title.  */
+  /** Titel på materialekomponenten. Efterlad dette felt blankt, hvis du ikke vil give den en overskrift. */
   materialGridTitle?: Maybe<Scalars['String']['output']>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
-/** A basic, formatted body of text. */
+/** En basal, formateret brødtekst */
 export type ParagraphTextBody = ParagraphInterface & {
   __typename?: 'ParagraphTextBody';
-  /** Body */
+  /** Brødtekst */
   body?: Maybe<Text>;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -926,25 +949,25 @@ export type ParagraphTextBody = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
 /** Entity type paragraph. */
-export type ParagraphUnion = ParagraphAccordion | ParagraphBanner | ParagraphBreadcrumbChildren | ParagraphCardGridAutomatic | ParagraphCardGridManual | ParagraphContentSlider | ParagraphContentSliderAutomatic | ParagraphFilteredEventList | ParagraphGoLinkbox | ParagraphGoMaterialSliderAutomatic | ParagraphGoMaterialSliderManual | ParagraphGoVideo | ParagraphGoVideoBundleAutomatic | ParagraphGoVideoBundleManual | ParagraphManualEventList | ParagraphMaterialGridAutomatic | ParagraphMaterialGridManual | ParagraphTextBody | ParagraphVideo;
+export type ParagraphUnion = ParagraphAccordion | ParagraphBanner | ParagraphBreadcrumbChildren | ParagraphCardGridAutomatic | ParagraphCardGridManual | ParagraphContentSlider | ParagraphContentSliderAutomatic | ParagraphFilteredEventList | ParagraphGoLink | ParagraphGoLinkbox | ParagraphGoMaterialSliderAutomatic | ParagraphGoMaterialSliderManual | ParagraphGoVideo | ParagraphGoVideoBundleAutomatic | ParagraphGoVideoBundleManual | ParagraphManualEventList | ParagraphMaterialGridAutomatic | ParagraphMaterialGridManual | ParagraphTextBody | ParagraphVideo;
 
-/** Enter the URL for the video you want to include. */
+/** Indtast URL'en til den video, du vil indlejre. */
 export type ParagraphVideo = ParagraphInterface & {
   __typename?: 'ParagraphVideo';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Embed video */
+  /** Indlejr video */
   embedVideo?: Maybe<MediaUnion>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
 };
 
@@ -1092,9 +1115,9 @@ export type TermBreadcrumbStructure = TermInterface & {
   __typename?: 'TermBreadcrumbStructure';
   /** Datoen hvor termen senest blev redigeret. */
   changed: DateTime;
-  /** The title that is shown above the list of referenced content. Will not be shown, if there are no children displayed. */
+  /** Titlen, der vises over listen af refereret indhold. Vil ikke blive vist, hvis der ikke vises nogen børn. */
   childrenTitle?: Maybe<Scalars['String']['output']>;
-  /** Content */
+  /** Indhold der linkes til */
   content: NodeUnion;
   /** Beskrivelse */
   description: Text;
@@ -1102,17 +1125,17 @@ export type TermBreadcrumbStructure = TermInterface & {
   id: Scalars['ID']['output'];
   /** Term sprogkode. */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Denne terms overordnede termer. */
   parent?: Maybe<TermUnion>;
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Should a list of contents that reference this breadcrumb, be shown automatically on this page? */
+  /** Vis en automatisk liste med indhold, som refererer til dette brødkrumme element, på denne side. */
   showChildren?: Maybe<Scalars['Boolean']['output']>;
   /** If this is checked, the children teasers will be expanded with possible subtitle descriptions. */
   showChildrenSubtitles?: Maybe<Scalars['Boolean']['output']>;
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Vægten af denne term i forhold til andre termer. */
   weight: Scalars['Int']['output'];
@@ -1129,13 +1152,13 @@ export type TermCategories = TermInterface & {
   id: Scalars['ID']['output'];
   /** Term sprogkode. */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Denne terms overordnede termer. */
   parent?: Maybe<TermUnion>;
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Vægten af denne term i forhold til andre termer. */
   weight: Scalars['Int']['output'];
@@ -1151,19 +1174,19 @@ export type TermInterface = {
   id: Scalars['ID']['output'];
   /** Term sprogkode. */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Denne terms overordnede termer. */
   parent?: Maybe<TermUnion>;
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Vægten af denne term i forhold til andre termer. */
   weight: Scalars['Int']['output'];
 };
 
-/** Kategorier af åbningstider, f.eks. "Åbent" eller "Telefontid" */
+/** This is for adding types of opening hours, e.g. "open" or "Telephone time" */
 export type TermOpeningHoursCategories = TermInterface & {
   __typename?: 'TermOpeningHoursCategories';
   /** Datoen hvor termen senest blev redigeret. */
@@ -1174,13 +1197,13 @@ export type TermOpeningHoursCategories = TermInterface & {
   id: Scalars['ID']['output'];
   /** Term sprogkode. */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Denne terms overordnede termer. */
   parent?: Maybe<TermUnion>;
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Vægten af denne term i forhold til andre termer. */
   weight: Scalars['Int']['output'];
@@ -1197,13 +1220,13 @@ export type TermScreenName = TermInterface & {
   id: Scalars['ID']['output'];
   /** Term sprogkode. */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Denne terms overordnede termer. */
   parent?: Maybe<TermUnion>;
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Vægten af denne term i forhold til andre termer. */
   weight: Scalars['Int']['output'];
@@ -1220,13 +1243,13 @@ export type TermTags = TermInterface & {
   id: Scalars['ID']['output'];
   /** Term sprogkode. */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Denne terms overordnede termer. */
   parent?: Maybe<TermUnion>;
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Vægten af denne term i forhold til andre termer. */
   weight: Scalars['Int']['output'];
@@ -1248,13 +1271,13 @@ export type TermWebformEmailCategories = TermInterface & {
   id: Scalars['ID']['output'];
   /** Term sprogkode. */
   langcode: Language;
-  /** Name */
+  /** Navn */
   name: Scalars['String']['output'];
   /** Denne terms overordnede termer. */
   parent?: Maybe<TermUnion>;
   /** Alternativ URL */
   path: Scalars['String']['output'];
-  /** Published */
+  /** Publiceret */
   status: Scalars['Boolean']['output'];
   /** Vægten af denne term i forhold til andre termer. */
   weight: Scalars['Int']['output'];
@@ -1328,19 +1351,24 @@ export type GetArticleQueryVariables = Exact<{
 }>;
 
 
-export type GetArticleQuery = { __typename?: 'Query', nodeArticle?: { __typename?: 'NodeArticle', title: string, subtitle?: string | null, paragraphs?: Array<{ __typename: 'ParagraphAccordion' } | { __typename: 'ParagraphBanner' } | { __typename: 'ParagraphBreadcrumbChildren' } | { __typename: 'ParagraphCardGridAutomatic' } | { __typename: 'ParagraphCardGridManual' } | { __typename: 'ParagraphContentSlider' } | { __typename: 'ParagraphContentSliderAutomatic' } | { __typename: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoLinkbox' } | { __typename: 'ParagraphGoMaterialSliderAutomatic' } | { __typename: 'ParagraphGoMaterialSliderManual' } | { __typename: 'ParagraphGoVideo' } | { __typename: 'ParagraphGoVideoBundleAutomatic' } | { __typename: 'ParagraphGoVideoBundleManual' } | { __typename: 'ParagraphManualEventList' } | { __typename: 'ParagraphMaterialGridAutomatic' } | { __typename: 'ParagraphMaterialGridManual' } | { __typename: 'ParagraphTextBody', body?: { __typename?: 'Text', value?: string | null } | null } | { __typename: 'ParagraphVideo' }> | null } | null };
+export type GetArticleQuery = { __typename?: 'Query', nodeArticle?: { __typename?: 'NodeArticle', title: string, subtitle?: string | null, paragraphs?: Array<{ __typename: 'ParagraphAccordion' } | { __typename: 'ParagraphBanner' } | { __typename: 'ParagraphBreadcrumbChildren' } | { __typename: 'ParagraphCardGridAutomatic' } | { __typename: 'ParagraphCardGridManual' } | { __typename: 'ParagraphContentSlider' } | { __typename: 'ParagraphContentSliderAutomatic' } | { __typename: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox' } | { __typename: 'ParagraphGoMaterialSliderAutomatic' } | { __typename: 'ParagraphGoMaterialSliderManual' } | { __typename: 'ParagraphGoVideo' } | { __typename: 'ParagraphGoVideoBundleAutomatic' } | { __typename: 'ParagraphGoVideoBundleManual' } | { __typename: 'ParagraphManualEventList' } | { __typename: 'ParagraphMaterialGridAutomatic' } | { __typename: 'ParagraphMaterialGridManual' } | { __typename: 'ParagraphTextBody', body?: { __typename?: 'Text', value?: string | null } | null } | { __typename: 'ParagraphVideo' }> | null } | null };
 
 export type GetDplCmsConfigurationQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetDplCmsConfigurationQuery = { __typename?: 'Query', dplConfiguration?: { __typename?: 'DplConfiguration', unilogin?: { __typename?: 'UniloginConfiguration', unilogin_api_url?: string | null, unilogin_api_wellknown_url?: string | null, unilogin_api_client_id?: string | null, unilogin_api_client_secret?: string | null } | null } | null };
+export type GetDplCmsConfigurationQuery = { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', unilogin?: { __typename?: 'UniloginConfiguration', unilogin_api_client_id?: string | null, unilogin_api_client_secret?: string | null, unilogin_api_url?: string | null, unilogin_api_wellknown_url?: string | null } | null } | null };
+
+export type GetLoginUrlsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetLoginUrlsQuery = { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', loginUrls?: { __typename?: 'GoLoginUrls', adgangsplatformen?: string | null } | null } | null };
 
 export type GetPageByPathQueryVariables = Exact<{
   path: Scalars['String']['input'];
 }>;
 
 
-export type GetPageByPathQuery = { __typename?: 'Query', route?: { __typename: 'RouteExternal' } | { __typename: 'RouteInternal', url: string, entity?: { __typename?: 'NodeGoArticle' } | { __typename?: 'NodeGoCategory' } | { __typename?: 'NodeGoPage', paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphVideo' }> | null } | null } | { __typename: 'RouteRedirect' } | null };
+export type GetPageByPathQuery = { __typename?: 'Query', route?: { __typename: 'RouteExternal' } | { __typename: 'RouteInternal', url: string, entity?: { __typename?: 'NodeGoArticle' } | { __typename?: 'NodeGoCategory' } | { __typename?: 'NodeGoPage', paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoLink' } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphVideo' }> | null } | null } | { __typename: 'RouteRedirect' } | null };
 
 export type GetAdgangsplatformenTokensQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1408,16 +1436,16 @@ export const useSuspenseGetArticleQuery = <
 useSuspenseGetArticleQuery.getKey = (variables: GetArticleQueryVariables) => ['getArticleSuspense', variables];
 
 
-useGetArticleQuery.fetcher = (variables: GetArticleQueryVariables, options?: RequestInit['headers']) => fetcher<GetArticleQuery, GetArticleQueryVariables>(GetArticleDocument, variables, options);
+useGetArticleQuery.fetcher = (variables: GetArticleQueryVariables, options?: RequestInit & { next?: NextFetchRequestConfig }) => fetcher<GetArticleQuery, GetArticleQueryVariables>(GetArticleDocument, variables, options);
 
 export const GetDplCmsConfigurationDocument = `
     query getDplCmsConfiguration {
-  dplConfiguration {
+  goConfiguration {
     unilogin {
-      unilogin_api_url
-      unilogin_api_wellknown_url
       unilogin_api_client_id
       unilogin_api_client_secret
+      unilogin_api_url
+      unilogin_api_wellknown_url
     }
   }
 }
@@ -1460,7 +1488,56 @@ export const useSuspenseGetDplCmsConfigurationQuery = <
 useSuspenseGetDplCmsConfigurationQuery.getKey = (variables?: GetDplCmsConfigurationQueryVariables) => variables === undefined ? ['getDplCmsConfigurationSuspense'] : ['getDplCmsConfigurationSuspense', variables];
 
 
-useGetDplCmsConfigurationQuery.fetcher = (variables?: GetDplCmsConfigurationQueryVariables, options?: RequestInit['headers']) => fetcher<GetDplCmsConfigurationQuery, GetDplCmsConfigurationQueryVariables>(GetDplCmsConfigurationDocument, variables, options);
+useGetDplCmsConfigurationQuery.fetcher = (variables?: GetDplCmsConfigurationQueryVariables, options?: RequestInit & { next?: NextFetchRequestConfig }) => fetcher<GetDplCmsConfigurationQuery, GetDplCmsConfigurationQueryVariables>(GetDplCmsConfigurationDocument, variables, options);
+
+export const GetLoginUrlsDocument = `
+    query getLoginUrls {
+  goConfiguration {
+    loginUrls {
+      adgangsplatformen
+    }
+  }
+}
+    `;
+
+export const useGetLoginUrlsQuery = <
+      TData = GetLoginUrlsQuery,
+      TError = unknown
+    >(
+      variables?: GetLoginUrlsQueryVariables,
+      options?: Omit<UseQueryOptions<GetLoginUrlsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<GetLoginUrlsQuery, TError, TData>['queryKey'] }
+    ) => {
+    
+    return useQuery<GetLoginUrlsQuery, TError, TData>(
+      {
+    queryKey: variables === undefined ? ['getLoginUrls'] : ['getLoginUrls', variables],
+    queryFn: fetcher<GetLoginUrlsQuery, GetLoginUrlsQueryVariables>(GetLoginUrlsDocument, variables),
+    ...options
+  }
+    )};
+
+useGetLoginUrlsQuery.getKey = (variables?: GetLoginUrlsQueryVariables) => variables === undefined ? ['getLoginUrls'] : ['getLoginUrls', variables];
+
+export const useSuspenseGetLoginUrlsQuery = <
+      TData = GetLoginUrlsQuery,
+      TError = unknown
+    >(
+      variables?: GetLoginUrlsQueryVariables,
+      options?: Omit<UseSuspenseQueryOptions<GetLoginUrlsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseSuspenseQueryOptions<GetLoginUrlsQuery, TError, TData>['queryKey'] }
+    ) => {
+    
+    return useSuspenseQuery<GetLoginUrlsQuery, TError, TData>(
+      {
+    queryKey: variables === undefined ? ['getLoginUrlsSuspense'] : ['getLoginUrlsSuspense', variables],
+    queryFn: fetcher<GetLoginUrlsQuery, GetLoginUrlsQueryVariables>(GetLoginUrlsDocument, variables),
+    ...options
+  }
+    )};
+
+useSuspenseGetLoginUrlsQuery.getKey = (variables?: GetLoginUrlsQueryVariables) => variables === undefined ? ['getLoginUrlsSuspense'] : ['getLoginUrlsSuspense', variables];
+
+
+useGetLoginUrlsQuery.fetcher = (variables?: GetLoginUrlsQueryVariables, options?: RequestInit & { next?: NextFetchRequestConfig }) => fetcher<GetLoginUrlsQuery, GetLoginUrlsQueryVariables>(GetLoginUrlsDocument, variables, options);
 
 export const GetPageByPathDocument = `
     query getPageByPath($path: String!) {
@@ -1531,7 +1608,7 @@ export const useSuspenseGetPageByPathQuery = <
 useSuspenseGetPageByPathQuery.getKey = (variables: GetPageByPathQueryVariables) => ['getPageByPathSuspense', variables];
 
 
-useGetPageByPathQuery.fetcher = (variables: GetPageByPathQueryVariables, options?: RequestInit['headers']) => fetcher<GetPageByPathQuery, GetPageByPathQueryVariables>(GetPageByPathDocument, variables, options);
+useGetPageByPathQuery.fetcher = (variables: GetPageByPathQueryVariables, options?: RequestInit & { next?: NextFetchRequestConfig }) => fetcher<GetPageByPathQuery, GetPageByPathQueryVariables>(GetPageByPathDocument, variables, options);
 
 export const GetAdgangsplatformenTokensDocument = `
     query getAdgangsplatformenTokens {
@@ -1581,7 +1658,7 @@ export const useSuspenseGetAdgangsplatformenTokensQuery = <
 useSuspenseGetAdgangsplatformenTokensQuery.getKey = (variables?: GetAdgangsplatformenTokensQueryVariables) => variables === undefined ? ['getAdgangsplatformenTokensSuspense'] : ['getAdgangsplatformenTokensSuspense', variables];
 
 
-useGetAdgangsplatformenTokensQuery.fetcher = (variables?: GetAdgangsplatformenTokensQueryVariables, options?: RequestInit['headers']) => fetcher<GetAdgangsplatformenTokensQuery, GetAdgangsplatformenTokensQueryVariables>(GetAdgangsplatformenTokensDocument, variables, options);
+useGetAdgangsplatformenTokensQuery.fetcher = (variables?: GetAdgangsplatformenTokensQueryVariables, options?: RequestInit & { next?: NextFetchRequestConfig }) => fetcher<GetAdgangsplatformenTokensQuery, GetAdgangsplatformenTokensQueryVariables>(GetAdgangsplatformenTokensDocument, variables, options);
 
 export const GetAdgangsplatformenUserTokenDocument = `
     query getAdgangsplatformenUserToken {
@@ -1630,4 +1707,4 @@ export const useSuspenseGetAdgangsplatformenUserTokenQuery = <
 useSuspenseGetAdgangsplatformenUserTokenQuery.getKey = (variables?: GetAdgangsplatformenUserTokenQueryVariables) => variables === undefined ? ['getAdgangsplatformenUserTokenSuspense'] : ['getAdgangsplatformenUserTokenSuspense', variables];
 
 
-useGetAdgangsplatformenUserTokenQuery.fetcher = (variables?: GetAdgangsplatformenUserTokenQueryVariables, options?: RequestInit['headers']) => fetcher<GetAdgangsplatformenUserTokenQuery, GetAdgangsplatformenUserTokenQueryVariables>(GetAdgangsplatformenUserTokenDocument, variables, options);
+useGetAdgangsplatformenUserTokenQuery.fetcher = (variables?: GetAdgangsplatformenUserTokenQueryVariables, options?: RequestInit & { next?: NextFetchRequestConfig }) => fetcher<GetAdgangsplatformenUserTokenQuery, GetAdgangsplatformenUserTokenQueryVariables>(GetAdgangsplatformenUserTokenDocument, variables, options);

--- a/lib/graphql/queries/configuration.dpl-cms.graphql
+++ b/lib/graphql/queries/configuration.dpl-cms.graphql
@@ -1,10 +1,10 @@
 query getDplCmsConfiguration {
-  dplConfiguration {
+  goConfiguration {
     unilogin {
-      unilogin_api_url
-      unilogin_api_wellknown_url
       unilogin_api_client_id
       unilogin_api_client_secret
+      unilogin_api_url
+      unilogin_api_wellknown_url
     }
   }
 }

--- a/lib/graphql/queries/login-urls.dpl-cms.graphql
+++ b/lib/graphql/queries/login-urls.dpl-cms.graphql
@@ -1,0 +1,7 @@
+query getLoginUrls {
+  goConfiguration {
+    loginUrls {
+      adgangsplatformen
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:unit": "vitest",
     "typecheck": "tsc --noEmit",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:run": "cypress run",
+    "post-process-dpl-cms-graphql": "NODE_OPTIONS='--loader=ts-node/esm' ts-node ./graphql-codegen-scripts/post-process-dpl-cms-graphql.ts"
   },
   "dependencies": {
     "@next/env": "15.0.3",
@@ -53,8 +54,10 @@
     "react-dom": "^19.0.0",
     "react-error-boundary": "^5.0.0",
     "react-parallax-tilt": "^1.7.252",
+    "replace-in-file": "^8.3.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
+    "ts-node": "^10.9.2",
     "vaul": "^1.1.1",
     "xstate": "^5.18.2",
     "zod": "^3.23.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,6 +1592,13 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@cypress/request@^3.0.6":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.7.tgz#6a74a4da98d9e5ae9121d6e2d9c14780c9b5cf1a"
@@ -2603,6 +2610,18 @@
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz#56f00962ff0c4e0eb93d34a047d29fa995e3e342"
   integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -2827,7 +2846,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
@@ -2849,6 +2868,14 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
@@ -3191,6 +3218,11 @@
     "@parcel/watcher-win32-arm64" "2.4.1"
     "@parcel/watcher-win32-ia32" "2.4.1"
     "@parcel/watcher-win32-x64" "2.4.1"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.11":
   version "0.5.15"
@@ -4555,6 +4587,26 @@
   resolved "https://registry.npmjs.org/@tsconfig/create-react-app/-/create-react-app-2.0.5.tgz"
   integrity sha512-NiXzSMJabQtVTPwFmBWX+eyee2dfhRSnQ6NNbtCZfXemGxOq+N0+RMPVYu+sz6riUZANHTnvvHoS1k87ksyDXg==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@types/aria-query@^5.0.1":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
@@ -5202,9 +5254,16 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.11.2, acorn@^8.14.0, acorn@^8.8.2, acorn@^8.9.0:
+acorn-walk@^8.1.1:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
+
+acorn@^8.11.0, acorn@^8.11.2, acorn@^8.14.0, acorn@^8.4.1, acorn@^8.8.2, acorn@^8.9.0:
   version "8.14.0"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 adjust-sourcemap-loader@^4.0.0:
@@ -5335,6 +5394,11 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
+ansi-styles@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+
 anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -5359,6 +5423,11 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -6113,6 +6182,11 @@ chalk@^5.2.0:
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
 
+chalk@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.4.1.tgz#1b48bf0963ec158dce2aacf69c093ae2dd2092d8"
+  integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
+
 change-case-all@1.0.14:
   version "1.0.14"
   resolved "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz"
@@ -6604,6 +6678,11 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@^3.1.5:
   version "3.1.8"
   resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz"
@@ -7013,6 +7092,11 @@ diff@5.1.0:
   resolved "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz"
   integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
 diffable-html@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/diffable-html/-/diffable-html-4.1.0.tgz#e7a2d1de187c4e23a59751b4e4c17483a058c696"
@@ -7172,6 +7256,11 @@ dset@^3.1.2:
   version "3.1.4"
   resolved "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz"
   integrity sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -8141,6 +8230,14 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
+foreground-child@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
+  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^4.0.1"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -8354,6 +8451,18 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob@^10.4.2:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
@@ -9288,6 +9397,15 @@ iterator.prototype@^1.1.3:
     has-symbols "^1.0.3"
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
 
 javascript-natural-sort@0.7.1:
   version "0.7.1"
@@ -10259,6 +10377,11 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -10303,6 +10426,11 @@ make-dir@^4.0.0:
   integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
   dependencies:
     semver "^7.5.3"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -10462,6 +10590,11 @@ minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 mkdirp@^1.0.4:
   version "1.0.4"
@@ -11084,6 +11217,11 @@ package-hash@^4.0.0:
     lodash.flattendeep "^4.4.0"
     release-zalgo "^1.0.0"
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -11209,6 +11347,14 @@ path-root@^0.1.1:
   integrity sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==
   dependencies:
     path-root-regex "^0.1.0"
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -11906,6 +12052,15 @@ renderkid@^3.0.0:
     lodash "^4.17.21"
     strip-ansi "^6.0.1"
 
+replace-in-file@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-8.3.0.tgz#53288f516fb8f3edc125c3af6b4b6adc2e5955bf"
+  integrity sha512-4VhddQiMCPIuypiwHDTM+XHjZoVu9h7ngBbSCnwGRcwdHwxltjt/m//Ep3GDwqaOx1fDSrKFQ+n7uo4uVcEz9Q==
+  dependencies:
+    chalk "^5.3.0"
+    glob "^10.4.2"
+    yargs "^17.7.2"
+
 request-progress@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
@@ -12344,6 +12499,11 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 signedsource@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz"
@@ -12567,6 +12727,15 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -12575,6 +12744,15 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"
@@ -12652,6 +12830,13 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -12986,6 +13171,25 @@ ts-log@^2.2.3:
   version "2.2.7"
   resolved "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz"
   integrity sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==
+
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
 
 ts-pnp@^1.1.6:
   version "1.2.0"
@@ -13365,6 +13569,11 @@ uuid@^9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 v8-to-istanbul@^9.0.1:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
@@ -13688,6 +13897,15 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
@@ -13705,6 +13923,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -13824,9 +14051,9 @@ yargs@^15.0.2, yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^17.0.0, yargs@^17.0.1, yargs@^17.3.1:
+yargs@^17.0.0, yargs@^17.0.1, yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
@@ -13844,6 +14071,11 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-353

#### Description

The work here is not tied to the Jira task itself but is needed for the login functionality in general.
The added functionality fetches the Adgangsplatformen login url for the Go application.

A post dpl-cms API graphql codgen script has been added that replaces `RequestInit["headers"]` with `RequestInit & { next?: NextFetchRequestConfig }` since we need to be able to pass the nextjs options to the fetcher in order to control the cache.
