### PR TITLE
Remove lint error in build

### DIFF
--- a/lib/machines/search/useSearchMachineActor.tsx
+++ b/lib/machines/search/useSearchMachineActor.tsx
@@ -59,9 +59,6 @@ const useSearchMachineActor = () => {
   const queryClient = useQueryClient()
   const actorRef = useRef(searchActor)
   const actor = actorRef.current
-  const searchQuery = useSelector(actor, snapshot => {
-    return snapshot.context.submittedQuery
-  })
   const storedQueryClient = useSelector(actor, snapshot => {
     return snapshot.context.queryClient
   })
@@ -111,7 +108,7 @@ const useSearchMachineActor = () => {
     }
 
     setPreviousPathname(currentPathname)
-  }, [searchParamString, searchQuery, pathname])
+  }, [pathname, searchParamString, previousPathname, actor])
 
   return actor
 }


### PR DESCRIPTION
In order to prevent lint error in build

The linter wants us to add all referenced deps in useEffect.
And an unused variable is removed.