### PR TITLE
Set NEXT_PUBLIC_APP_URL differently depending on environment

### DIFF
--- a/lagoon/start.sh
+++ b/lagoon/start.sh
@@ -10,7 +10,14 @@ getLagoonUrl() {
 }
 
 # Make sure app.url is set in application
-app_url=$(getLagoonUrl node)
+goUrlPrefix="go."
+# If the project is "dpl-cms", we are running in a PR environment
+# and then the goUrlPrefix should be go-.
+# Otherwise we are in production and the goUrlPrefix should be "go.".
+if [ "$LAGOON_PROJECT" = "dpl-cms" ]; then
+  goUrlPrefix="go-"
+fi
+app_url=$(getLagoonUrl $goUrlPrefix)
 if [ -z "$app_url" ]; then
   echo "Error: Unable to determine app URL"
   exit 1


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-463

#### Description

We cannot use an extra "go." subdomain in pr environments so we need to use "go-" prefix instead.
This fix makes it possible to use the [nginx annotation setting ](https://github.com/danskernesdigitalebibliotek/dpl-cms/blob/3357a502ccf5bdc59a0c51f4f2b16b905c698259/.lagoon.yml#L171-L173) we need for setting te go-session cookie .

