### PR TITLE
Try to ignore ts and eslint checks when building

### DIFF
--- a/lagoon/start.sh
+++ b/lagoon/start.sh
@@ -24,8 +24,14 @@ if [ -z "$app_url" ]; then
 fi
 
 # Make sure the DPL CMS graphql schema endpoint is set in application
-cms_url=$(getLagoonUrl nginx)
-
+goCmsUrlPrefix="nginx."
+# If the project is "dpl-cms", we are running in a PR environment
+# and then the goUrlPrefix should be gocms-.
+# Otherwise we are in production and the goUrlPrefix should be "nginx.".
+if [ "$LAGOON_PROJECT" = "dpl-cms" ]; then
+  goCmsUrlPrefix="gocms-"
+fi
+cms_url=$(getLagoonUrl $goCmsUrlPrefix)
 if [ -z "$cms_url" ]; then
   echo "Error: Unable to determine CMS URL"
   exit 1

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  typescript: {
+    // @todo This is a temporary solution!!
+    // We are trying to bring down the build time.
+    // Remember to remove this once the build time is optimized!!!
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    // @todo This is a temporary solution!!
+    // We are trying to bring down the build time.
+    // Remember to remove this once the build time is optimized!!!
+    ignoreDuringBuilds: true,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
This is only temporary but we want to see if we can get a faster build timer and go below the readiness threshold of k8s.
