### PR TITLE
Put `LogoutButton` in suspense boundary

### DIFF
--- a/app/user/profile/page.tsx
+++ b/app/user/profile/page.tsx
@@ -7,8 +7,8 @@ const Page = () => {
   return (
     <div className="content-container">
       <h1 className="text-typo-heading-3 pb-5 font-bold">Profile</h1>
-      <LogoutButton />
       <Suspense fallback={<p>Loading...</p>}>
+        <LogoutButton />
         <DebuggingSession />
       </Suspense>
     </div>


### PR DESCRIPTION
Since `useSession` (which is inside of the `LogoutButton`) uses `useSearchParams` we need to put the LogoutButton in a `Suspense` boundary.
