### PR TITLE
Rename insitution ids property

### DIFF
--- a/app/auth/callback/unilogin/route.ts
+++ b/app/auth/callback/unilogin/route.ts
@@ -11,7 +11,7 @@ import schemas from "./schemas"
 
 export interface TIntrospectionResponse extends client.IntrospectionResponse {
   uniid: string
-  institutionIds: string
+  institution_ids: string
 }
 
 export async function GET(request: NextRequest) {
@@ -75,7 +75,7 @@ export async function GET(request: NextRequest) {
     session.userInfo = {
       sub: userinfo.sub,
       uniid: introspect.uniid,
-      institutionIds: introspect.institutionIds,
+      institution_ids: introspect.institution_ids,
     }
 
     // TODO: When we have verified that it works in Lagoon

--- a/app/auth/callback/unilogin/schemas.ts
+++ b/app/auth/callback/unilogin/schemas.ts
@@ -10,7 +10,7 @@ const schemas = {
   }),
   introspect: z.object({
     uniid: z.string(),
-    institutionIds: z.string(),
+    institution_ids: z.string(),
   }),
   userInfo: z.object({
     sub: z.string(),

--- a/lib/session/session.ts
+++ b/lib/session/session.ts
@@ -38,7 +38,7 @@ export interface TSessionData {
   userInfo?: {
     sub: string
     uniid: string
-    institutionIds: string
+    institution_ids: string
   }
   adgangsplatformenUserToken?: string
   type: TSessionType


### PR DESCRIPTION
AMAZINGLY STIL all of a sudden renamed the property and Unilogin login was failing. This fixes the problem
