### PR TITLE
Fix inaccurate automatic accessibility test

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="da">
-      <body className={`${GTFlexa.variable} antialiased`}>
+      <body className={`${GTFlexa.variable} duration-dark-mode antialiased transition-all`}>
         <GridHelper hideInProduction />
         <Theme>
           <ReactQueryProvider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -372,7 +372,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background font-body text-foreground duration-dark-mode transition-all;
+    @apply bg-background font-body text-foreground;
   }
 }
 


### PR DESCRIPTION
#### Link to issue

[DDFBRA-448](https://reload.atlassian.net/browse/DDFBRA-448)

#### Description

When `duration-dark-mode` and `transition-all` is applied to the body element, it will also affect components in storybook, which causes the background to animate when loading a story. This causes axe to register the wrong colors, as colors are being animated while axe runs its checks.

This PR moved those mentioned classes to the Nextjs layout so stories will not have the transition effect. 