### PR TITLE
feat: Add hardcoded childrenOrAdults filter to search queries

### DIFF
--- a/lib/machines/search/queries.ts
+++ b/lib/machines/search/queries.ts
@@ -9,7 +9,11 @@ import {
   useSearchWithPaginationQuery,
 } from "@/lib/graphql/generated/fbi/graphql"
 
-import { TFilters } from "./types"
+import { TChildrenOrAdultsOption, TFilters } from "./types"
+
+const childrenOrAdultsFilter = {
+  childrenOrAdults: ["til børn"] as TChildrenOrAdultsOption[],
+}
 
 export const performSearch = fromPromise(
   ({
@@ -21,7 +25,7 @@ export const performSearch = fromPromise(
       q: { all: q },
       offset: offset,
       limit,
-      filters,
+      filters: { ...filters, ...childrenOrAdultsFilter },
     }
 
     return queryClient.fetchQuery({
@@ -41,7 +45,7 @@ export const getFacets = fromPromise(
       q: { all: q },
       facets: getFacetMachineNames(),
       facetLimit,
-      filters,
+      filters: { ...filters, ...childrenOrAdultsFilter },
     }
 
     return queryClient.fetchQuery({

--- a/lib/machines/search/types.ts
+++ b/lib/machines/search/types.ts
@@ -8,6 +8,8 @@ import {
 
 export type TFilters = Omit<SearchFiltersInput, "status">
 
+export type TChildrenOrAdultsOption = "til børn" | "til voksne"
+
 export type TContext = {
   facetLimit: number
   searchOffset: number


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-485

#### Description

This PR introduces a hardcoded filter to search results that ensures that only materials for children is fetched
