### PR TITLE
Added vitest helper function to run tests silently

### DIFF
--- a/__tests__/env.test.ts
+++ b/__tests__/env.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, expect, test } from "vitest"
 
 import { getEnv, getServerEnv } from "@/lib/config/env"
 
+import { testSilently } from "./helpers"
+
 beforeEach(() => {
   vi.unstubAllEnvs()
 })
@@ -13,15 +15,18 @@ test("That the env variable APP_URL defines the current app url", async () => {
   expect(appUrl).toBe("https://hellboy.the-movie.com")
 })
 
-test("That the env variable APP_URL validates the url", async () => {
+// test that we validate incorrect urls
+// runs silently to avoid expected errors in the console
+testSilently("That the env variable APP_URL validates the url", async () => {
   // set the env variable to a non-url value
   vi.stubEnv("NEXT_PUBLIC_APP_URL", "not-a-url")
 
   expect(() => getEnv("APP_URL")).toThrow()
 })
 
-// test that go_session_secret validates the length
-test("That the env variable GO_SESSION_SECRET validates the length", async () => {
+// test that we validate incorrect env length
+// runs silently to avoid expected errors in the console
+testSilently("That the env variable GO_SESSION_SECRET validates the length", async () => {
   vi.stubEnv("GO_SESSION_SECRET", "not-very-long")
 
   expect(() => getServerEnv("GO_SESSION_SECRET")).toThrow()

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,0 +1,55 @@
+import { vi, test as vitestTest } from "vitest"
+
+type ConsoleSpy = {
+  error: ReturnType<typeof vi.spyOn>
+  info: ReturnType<typeof vi.spyOn>
+}
+
+/**
+ * Helper function to silence console output during a test.
+ * Usage:
+ * ```ts
+ * test("my test", async () => {
+ *   const { restoreConsole } = withSilencedConsole()
+ *   // ... test code that might produce console output ...
+ *   restoreConsole()
+ * })
+ * ```
+ */
+export function withSilencedConsole() {
+  const consoleSpy: ConsoleSpy = {
+    error: vi.spyOn(console, "error").mockImplementation(() => {}),
+    info: vi.spyOn(console, "info").mockImplementation(() => {}),
+  }
+
+  return {
+    restoreConsole: () => {
+      consoleSpy.error.mockRestore()
+      consoleSpy.info.mockRestore()
+    },
+  }
+}
+
+/**
+ * Custom test wrapper that automatically silences console output.
+ * Usage:
+ * ```ts
+ * testSilently("my test", async () => {
+ *   // ... test code that might produce console output ...
+ * })
+ * ```
+ */
+export const testSilently = (name: string, fn: () => void | Promise<void>, timeout?: number) => {
+  vitestTest(
+    name,
+    async () => {
+      const { restoreConsole } = withSilencedConsole()
+      try {
+        await fn()
+      } finally {
+        restoreConsole()
+      }
+    },
+    timeout
+  )
+}


### PR DESCRIPTION
Sometimes we expect a test to throw errors, which sometimes also logs messages to the console. This will lead to confusion, because it looks like unitended errors while testing.
With this custom function we can silence those expected messages.
