### PR TITLE
Pass original request headers through to service

### DIFF
--- a/app/ap-service/[[...slug]]/route.ts
+++ b/app/ap-service/[[...slug]]/route.ts
@@ -27,6 +27,11 @@ async function proxyRequest(
   { params }: TContext,
   body?: string
 ) {
+  const proxiedHeaders: Record<string, string> = {}
+  request.headers.forEach((value, key) => {
+    proxiedHeaders[key] = value
+  })
+
   const { slug } = await params
   const serviceType = slug.shift() as TServiceType
   const baseUrl = getServiceSettings(serviceType)?.url ?? null
@@ -43,8 +48,7 @@ async function proxyRequest(
     const result = await fetch(serviceUrl, {
       method,
       headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
+        ...proxiedHeaders,
         ...(authHeader ? { Authorization: authHeader } : {}),
       },
       body,


### PR DESCRIPTION
Then we do not need to have any content-type header eg. logic. We simply pass along what we get.
