### PR TITLE
Do not use ap proxy on library requests

### DIFF
--- a/__tests__/pubhub.test.ts
+++ b/__tests__/pubhub.test.ts
@@ -25,7 +25,7 @@ describe("Pubhub local API", () => {
       Promise.resolve({
         isLoggedIn: true,
         type: "unilogin",
-        userInfo: { uniid: "100006cbab", institution_ids: ["A04441"] },
+        uniLoginUserInfo: { uniid: "100006cbab", institution_ids: ["A04441"] },
       })
     )
     vi.spyOn(clientFunctions, "createClientAsync").mockResolvedValue(
@@ -53,7 +53,7 @@ describe("Pubhub local API", () => {
       Promise.resolve({
         isLoggedIn: true,
         type: "unilogin",
-        userInfo: { uniid: "100006cbab", institution_ids: ["A04441"] },
+        uniLoginUserInfo: { uniid: "100006cbab", institution_ids: ["A04441"] },
       })
     )
     vi.spyOn(clientFunctions, "createClientAsync").mockResolvedValue(

--- a/app/ap-service/[[...slug]]/route.ts
+++ b/app/ap-service/[[...slug]]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 
+import { TServiceType, getApServiceSettings } from "@/lib/helpers/ap-service"
 import { getBearerTokenServerSide } from "@/lib/helpers/bearer-token"
-import { TServiceType, getServiceSettings } from "@/lib/helpers/services"
 import { getSession } from "@/lib/session/session"
 
 type TContext = { params: Promise<{ slug: string[] }> }
@@ -34,7 +34,7 @@ async function proxyRequest(
 
   const { slug } = await params
   const serviceType = slug.shift() as TServiceType
-  const baseUrl = getServiceSettings(serviceType)?.url ?? null
+  const baseUrl = getApServiceSettings(serviceType)?.url ?? null
   if (!baseUrl) {
     return new Response("Not found", { status: 404 })
   }
@@ -49,7 +49,7 @@ async function proxyRequest(
       method,
       headers: {
         ...proxiedHeaders,
-        ...(authHeader ? { Authorization: authHeader } : {}),
+        ...(authHeader ? { authorization: authHeader } : {}),
       },
       body,
     })

--- a/app/auth/callback/unilogin/route.ts
+++ b/app/auth/callback/unilogin/route.ts
@@ -94,7 +94,7 @@ export async function GET(request: NextRequest) {
 
     // UserInfo Request
     const userInfoResponse = await client.fetchUserInfo(config, tokenSet.access_token, claims.sub)
-    const userinfo = schemas.userInfo.parse(userInfoResponse)
+    const userinfo = schemas.uniLoginUserInfo.parse(userInfoResponse)
 
     // Set basic session info.
     session.isLoggedIn = true
@@ -118,13 +118,19 @@ export async function GET(request: NextRequest) {
 
     // Set user info.
     // TODO: After Publizon allows DDF test users to loan, we can remove thie if statement.
-    session.userInfo = {
+    session.uniLoginUserInfo = {
       sub: userinfo.sub,
       uniid: introspect.uniid,
       // TODO: Rename this into institutionIds
       institution_ids:
         institutionId === "A04441" ? ["101047"] : getInstitutionIds(introspect.institution_ids),
     }
+    session.user = {
+      // Unilogin does not provide a name, so we set it to undefined.
+      name: undefined,
+      username: introspect.uniid,
+    }
+
     await session.save()
   } catch (error) {
     console.error(error)

--- a/app/auth/callback/unilogin/schemas.ts
+++ b/app/auth/callback/unilogin/schemas.ts
@@ -13,7 +13,7 @@ const schemas = {
     uniid: z.string(),
     institution_ids: z.string(),
   }),
-  userInfo: z.object({
+  uniLoginUserInfo: z.object({
     sub: z.string(),
   }),
   institution: z.object({

--- a/app/pubhub/(lib)/helper.ts
+++ b/app/pubhub/(lib)/helper.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 
 import { getSession } from "@/lib/session/session"
 
-import { userInfoSchema } from "./schemas"
+import { uniLoginUserInfoSchema } from "./schemas"
 
 type Handler = <TContext>(req: NextRequest, context?: TContext) => Promise<Response>
 
@@ -17,10 +17,10 @@ export function withAuth(handler: Handler): Handler {
         isLoggedIn: z.literal(true),
         type: z.literal("unilogin"),
       }).parse(session)
-      const userInfo = userInfoSchema.parse(session?.userInfo)
+      const uniLoginUserInfo = uniLoginUserInfoSchema.parse(session?.uniLoginUserInfo)
 
       // If authenticated, call the original handler
-      return handler(req, { ...context, userInfo })
+      return handler(req, { ...context, uniLoginUserInfo })
     } catch (error) {
       console.error(error)
       return new Response("Not Authorized", { status: 401 })

--- a/app/pubhub/(lib)/schemas.ts
+++ b/app/pubhub/(lib)/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const userInfoSchema = z.object({
+export const uniLoginUserInfoSchema = z.object({
   uniid: z.string(),
   institution_ids: z.string().array(),
 })

--- a/app/pubhub/(lib)/types.ts
+++ b/app/pubhub/(lib)/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
 
-import { userInfoSchema } from "./schemas"
+import { uniLoginUserInfoSchema } from "./schemas"
 
-export type TUserInfo = z.infer<typeof userInfoSchema>
+export type TUserInfo = z.infer<typeof uniLoginUserInfoSchema>

--- a/app/pubhub/v1/user/loans/(lib)/requests.ts
+++ b/app/pubhub/v1/user/loans/(lib)/requests.ts
@@ -4,13 +4,13 @@ import { createClientAsync } from "@/lib/soap/publizon/v2_7/generated/getlibrary
 
 import { TLibraryUserOrderList } from "./types"
 
-export const getLibraryUserOrderListRequest = async (userInfo: TUserInfo) => {
+export const getLibraryUserOrderListRequest = async (uniLoginUserInfo: TUserInfo) => {
   const client = await createClientAsync(
     "./lib/soap/publizon/v2_7/wsdl/getlibraryuserorderlist.wsdl"
   )
   const [response] = await client.GetLibraryUserOrderListAsync({
     ...getPublizonServiceParameters(),
-    cardnumber: userInfo.uniid,
+    cardnumber: uniLoginUserInfo.uniid,
   })
   return response.GetLibraryUserOrderListResult as TLibraryUserOrderList
 }

--- a/app/pubhub/v1/user/loans/[identifier]/(lib)/requests.ts
+++ b/app/pubhub/v1/user/loans/[identifier]/(lib)/requests.ts
@@ -3,10 +3,10 @@ import { TCreateLoan } from "@/app/pubhub/v1/user/loans/[identifier]/(lib)/types
 import { getPublizonServiceParameters } from "@/lib/helpers/publizon"
 import { createClientAsync as createClientAsyncCreateLoan } from "@/lib/soap/publizon/v2_7/generated/createloan"
 
-export const createLoanRequest = async (userInfo: TUserInfo, ebookId: string) => {
+export const createLoanRequest = async (uniLoginUserInfo: TUserInfo, ebookId: string) => {
   const client = await createClientAsyncCreateLoan("./lib/soap/publizon/v2_7/wsdl/createloan.wsdl")
   const { clientid, retailerid, retailerkeycode } = getPublizonServiceParameters()
-  const institutionid = userInfo.institution_ids[0]
+  const institutionid = uniLoginUserInfo.institution_ids[0]
   if (!institutionid) {
     throw new Error("Institution id not found")
   }
@@ -14,7 +14,7 @@ export const createLoanRequest = async (userInfo: TUserInfo, ebookId: string) =>
     retailerid,
     retailerkeycode,
     ebookid: ebookId,
-    cardnumber: userInfo.uniid,
+    cardnumber: uniLoginUserInfo.uniid,
     clientid,
     institutionid: institutionid,
   })

--- a/app/pubhub/v1/user/loans/[identifier]/route.ts
+++ b/app/pubhub/v1/user/loans/[identifier]/route.ts
@@ -9,7 +9,7 @@ import { createLoanSchema } from "./(lib)/schemas"
 
 async function createdigitalLoan(
   request: NextRequest,
-  context: { userInfo: TUserInfo; params: { identifier: string } }
+  context: { uniLoginUserInfo: TUserInfo; params: { identifier: string } }
 ) {
   const { identifier } = context.params
   const createLoan = createLoanSchema.transform(loanData => {
@@ -23,7 +23,7 @@ async function createdigitalLoan(
     }
   })
   try {
-    const responseData = await createLoanRequest(context.userInfo, identifier)
+    const responseData = await createLoanRequest(context.uniLoginUserInfo, identifier)
     return NextResponse.json(createLoan.parse(responseData))
   } catch (error) {
     console.error(error)

--- a/app/pubhub/v1/user/loans/route.ts
+++ b/app/pubhub/v1/user/loans/route.ts
@@ -8,8 +8,8 @@ import { getLibraryUserOrderListRequest } from "./(lib)/requests"
 import { libraryUserOrderListSchema } from "./(lib)/schemas"
 import { isOrderItem } from "./(lib)/types"
 
-async function getLibraryUserOrder(request: NextRequest, context: { userInfo: TUserInfo }) {
-  const { userInfo } = context
+async function getLibraryUserOrder(request: NextRequest, context: { uniLoginUserInfo: TUserInfo }) {
+  const { uniLoginUserInfo } = context
   const libraryUserOrderList = libraryUserOrderListSchema.transform(orderListData => {
     const orderListResponse = orderListData.response
     const orderItem = orderListResponse.data.orderitem
@@ -44,7 +44,7 @@ async function getLibraryUserOrder(request: NextRequest, context: { userInfo: TU
   })
 
   try {
-    const responseData = await getLibraryUserOrderListRequest(userInfo)
+    const responseData = await getLibraryUserOrderListRequest(uniLoginUserInfo)
     return NextResponse.json(libraryUserOrderList.parse(responseData))
   } catch (error) {
     console.error(error)

--- a/app/user/profile/ProfilePageLayout.tsx
+++ b/app/user/profile/ProfilePageLayout.tsx
@@ -6,6 +6,8 @@ import LogoutButton from "@/app/user/profile/LogoutButton"
 import UserLoans from "@/app/user/profile/UserLoans"
 import { ButtonSkeleton } from "@/components/shared/button/Button"
 
+import Username, { UsernameSkeleton } from "./Username"
+
 const ProfilePageLayout = () => {
   return (
     <div className="content-container grid-go -mt-space-y w-full space-y-3">
@@ -14,9 +16,7 @@ const ProfilePageLayout = () => {
         <Suspense fallback={<ButtonSkeleton size="sm" />}>
           <LogoutButton />
         </Suspense>
-        <p className="text-typo-heading-2 mt-6 w-full pb-5 lg:order-1 lg:mt-0 lg:w-auto lg:max-w-[80%]">
-          Username / User Name
-        </p>
+        <Username />
       </div>
       <UserLoans />
       <DebuggingSession />
@@ -30,7 +30,7 @@ export const ProfilePageLayoutSkeleton = () => {
       <div className="col-span-full flex flex-row flex-wrap">
         <h1 className="text-typo-subtitle-sm mb-5 lg:w-full">Profile</h1>
         <ButtonSkeleton size="sm" className="ml-auto justify-end lg:order-2" />
-        {/* username skeleton */}
+        <UsernameSkeleton />
         <div
           className="text-typo-heading-2 bg-background-skeleton h-[46px] w-full animate-pulse rounded-sm lg:h-[66px]
             lg:w-96"

--- a/app/user/profile/Username.tsx
+++ b/app/user/profile/Username.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import useSession from "@/hooks/useSession"
+import { cn } from "@/lib/helpers/helper.cn"
+
+type UsernameProps = {
+  className?: string
+}
+
+export const UsernameSkeleton = ({ className }: UsernameProps) => (
+  <div
+    className={cn(
+      "bg-background-skeleton mb-6 h-10 w-100 animate-pulse rounded-full pb-5",
+      className
+    )}
+  />
+)
+
+const Username = ({ className }: UsernameProps) => {
+  const { session, isLoading: sessionIsLoading } = useSession()
+
+  if (sessionIsLoading) {
+    return <UsernameSkeleton />
+  }
+
+  const name = (session?.user?.name || session?.user?.username) ?? null
+
+  if (!name) {
+    return null
+  }
+
+  return (
+    <p
+      className={cn(
+        "text-typo-heading-2 mt-6 w-full pb-5 lg:order-1 lg:mt-0 lg:w-auto lg:max-w-[80%]",
+        className
+      )}>
+      {name}
+    </p>
+  )
+}
+export default Username

--- a/lib/fetchers/helper.ts
+++ b/lib/fetchers/helper.ts
@@ -31,10 +31,10 @@ export const buildParams = (data: FetchParams) => {
 
 export const createAuthHeader = (
   token: RequestOptions["bearerToken"]
-): { Authorization: `Bearer ${string}` } | Record<string, never> =>
+): { authorization: `Bearer ${string}` } | Record<string, never> =>
   token
     ? {
-        Authorization: `Bearer ${token}`,
+        authorization: `Bearer ${token}`,
       }
     : {}
 

--- a/lib/helpers/ap-service.ts
+++ b/lib/helpers/ap-service.ts
@@ -3,6 +3,6 @@ import goConfig from "../config/goConfig"
 const serviceSettings = goConfig("services.url-and-library-token-settings")
 export type TServiceType = keyof typeof serviceSettings
 
-export const getServiceSettings = (serviceType: TServiceType) => {
+export const getApServiceSettings = (serviceType: TServiceType) => {
   return serviceSettings[serviceType as TServiceType] ?? null
 }

--- a/lib/helpers/bearer-token.ts
+++ b/lib/helpers/bearer-token.ts
@@ -11,14 +11,14 @@ import {
   setUniloginTokensOnSession,
 } from "../session/session"
 import { TUniloginTokenSet } from "../types/session"
+import { TServiceType, getApServiceSettings } from "./ap-service"
 import { getLibraryTokenCookieValue } from "./library-token"
-import { TServiceType, getServiceSettings } from "./services"
 
 export const getBearerTokenServerSide = async (
   serviceType: TServiceType,
   session?: IronSession<TSessionData>
 ) => {
-  const useLibraryToken = getServiceSettings(serviceType)?.useLibraryTokenAlways ?? true
+  const useLibraryToken = getApServiceSettings(serviceType)?.useLibraryTokenAlways ?? true
   const libraryToken = await getLibraryTokenCookieValue()
   const userToken = session?.adgangsplatformenUserToken
   if (useLibraryToken && libraryToken) {
@@ -44,7 +44,7 @@ export const createServerQueryFn = async <TQuery, TVariables>(
   const session = await getSession()
   const bearerToken = await getBearerTokenServerSide("fbi", session)
 
-  return fetcher(variables, { ...options, Authorization: `Bearer ${bearerToken}` })
+  return fetcher(variables, { ...options, authorization: `Bearer ${bearerToken}` })
 }
 
 export const refreshUniloginTokens = async (

--- a/lib/helpers/fbs.ts
+++ b/lib/helpers/fbs.ts
@@ -1,0 +1,25 @@
+import getQueryClient from "../getQueryClient"
+import { getGetPatronInformationByPatronIdV2QueryOptions } from "../rest/fbs/generated/fbs"
+import { AuthenticatedPatronV6 } from "../rest/fbs/generated/model"
+import { fetcher } from "../rest/fbs/mutator/fetcher"
+
+export const loadPatronServerSide = async (accessToken: string) => {
+  const queryClient = getQueryClient()
+  const { queryKey } = getGetPatronInformationByPatronIdV2QueryOptions()
+  const patronInfoUrl = queryKey[0] as string
+
+  const response = await queryClient.fetchQuery({
+    queryKey,
+    queryFn: ({ signal }) =>
+      fetcher<AuthenticatedPatronV6>({
+        url: patronInfoUrl,
+        method: "GET",
+        signal,
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+      }),
+  })
+
+  return response
+}

--- a/lib/rest/fbs/mutator/fetcher.ts
+++ b/lib/rest/fbs/mutator/fetcher.ts
@@ -11,7 +11,7 @@ export const fetcher = async <ResponseType>({
 }: {
   url: string
   method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD"
-  headers?: object
+  headers?: HeadersInit
   params?: unknown
   data?: BodyType<unknown>
   signal?: AbortSignal

--- a/lib/rest/publizon/local-adapter/mutator/fetcher.ts
+++ b/lib/rest/publizon/local-adapter/mutator/fetcher.ts
@@ -16,10 +16,6 @@ export const fetcher = async <ResponseType>({
   data?: BodyType<unknown>
   signal?: AbortSignal
 }) => {
-  const authHeaders = {
-    Authorization: `Bearer ${getEnv("LIBRARY_TOKEN")}`,
-  } as object
-
   const body = data ? JSON.stringify(data) : null
   const serviceUrl = getRestServiceUrlWithParams({
     baseUrl: `${getEnv("APP_URL")}/${goConfig("routes.pubhub")}`,
@@ -32,7 +28,6 @@ export const fetcher = async <ResponseType>({
       method,
       headers: {
         ...headers,
-        ...authHeaders,
       },
       body,
     })


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-508

#### Description

This PR should be merged after [this one](https://github.com/danskernesdigitalebibliotek/dpl-go/pull/208) has been reviewed because it contains a lot of the same commits.

The main focus in this PR is to make sure that Adgangsplatform services that are not dependent on an authorized user (aka only uses library token) do NOT use the ap service proxy, because we never need to attach the user token server side.
Right now the cover service is a service that only needs the library token and therefor is not being proxied.

But this PR also introduces a function for resolving the auth header in the AP service fetchers, so it is done in a uniform way.
And this PR makes sure that it is always possible to override the fetch headers from outside the fetchers.

