### PR TITLE
Do not use AP proxy on useLibraryTokenAlways services

### DIFF
--- a/app/ap-service/[[...slug]]/route.ts
+++ b/app/ap-service/[[...slug]]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 
-import { TServiceType, getApServiceSettings } from "@/lib/helpers/ap-service"
+import { TServiceType, getApServiceUrl } from "@/lib/helpers/ap-service"
 import { getBearerTokenServerSide } from "@/lib/helpers/bearer-token"
-import { getSession } from "@/lib/session/session"
 
 type TContext = { params: Promise<{ slug: string[] }> }
 
@@ -13,8 +12,7 @@ const getAuthHeader = async (request: NextRequest, serviceType: TServiceType) =>
     return authHeader
   }
   // Otherwise, get the bearer token from the session or library token cookie.
-  const session = await getSession()
-  const bearerToken = await getBearerTokenServerSide(serviceType, session)
+  const bearerToken = await getBearerTokenServerSide(serviceType)
   if (bearerToken) {
     return `Bearer ${bearerToken}`
   }
@@ -34,7 +32,8 @@ async function proxyRequest(
 
   const { slug } = await params
   const serviceType = slug.shift() as TServiceType
-  const baseUrl = getApServiceSettings(serviceType)?.url ?? null
+  const baseUrl = getApServiceUrl(serviceType)
+
   if (!baseUrl) {
     return new Response("Not found", { status: 404 })
   }
@@ -48,8 +47,8 @@ async function proxyRequest(
     const result = await fetch(serviceUrl, {
       method,
       headers: {
-        ...proxiedHeaders,
         ...(authHeader ? { authorization: authHeader } : {}),
+        ...proxiedHeaders,
       },
       body,
     })

--- a/lib/config/resolvers/services.ts
+++ b/lib/config/resolvers/services.ts
@@ -1,5 +1,5 @@
 const services = {
-  "services.url-and-library-token-settings": {
+  "services.ap-services": {
     covers: { url: "https://cover.dandigbib.org", useLibraryTokenAlways: true },
     fbi: { url: "https://temp.fbi-api.dbc.dk/ereolgo/graphql", useLibraryTokenAlways: false },
     "pubhub-adapter": { url: "https://pubhub-openplatform.dbc.dk", useLibraryTokenAlways: false },

--- a/lib/graphql/fetchers/fbi.fetcher.ts
+++ b/lib/graphql/fetchers/fbi.fetcher.ts
@@ -1,5 +1,4 @@
-import { getEnv } from "@/lib/config/env"
-import goConfig from "@/lib/config/goConfig"
+import { getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
 
 export const fetchData = <TData, TVariables>(
   query: string,
@@ -7,20 +6,18 @@ export const fetchData = <TData, TVariables>(
   options?: RequestInit["headers"]
 ): (() => Promise<TData>) => {
   return async () => {
-    const res = await fetch(
-      `${getEnv("APP_URL")}/${goConfig("routes.adgangsplatformen-service-proxy")}/fbi`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...options,
-        },
-        body: JSON.stringify({
-          query,
-          variables,
-        }),
-      }
-    )
+    const url = getAPServiceFetcherBaseUrl("fbi")
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...options,
+      },
+      body: JSON.stringify({
+        query,
+        variables,
+      }),
+    })
     const json = await res.json()
 
     if (json.errors) {

--- a/lib/helpers/ap-service.ts
+++ b/lib/helpers/ap-service.ts
@@ -1,8 +1,44 @@
+import { getEnv } from "../config/env"
 import goConfig from "../config/goConfig"
+import { getLibraryTokenCookieValue } from "./library-token"
 
-const serviceSettings = goConfig("services.url-and-library-token-settings")
+const serviceSettings = goConfig("services.ap-services")
 export type TServiceType = keyof typeof serviceSettings
 
 export const getApServiceSettings = (serviceType: TServiceType) => {
   return serviceSettings[serviceType as TServiceType] ?? null
+}
+
+export const getApServiceUrl = (serviceType: TServiceType) => {
+  const serviceSettings = getApServiceSettings(serviceType)
+  if (!serviceSettings) {
+    throw new Error(`No url found for the ${serviceType} service`)
+  }
+
+  return serviceSettings.url
+}
+
+export const getAPServiceFetcherBaseUrl = (serviceType: TServiceType) => {
+  const serviceSettings = getApServiceSettings(serviceType)
+  const serviceUrl = getApServiceUrl(serviceType)
+
+  // If we always use the library token,
+  // there is no need to use the Adangsplatformen service proxy.
+  // And we can use the service url directly.
+  if (serviceSettings?.useLibraryTokenAlways) {
+    return serviceUrl
+  }
+
+  return `${getEnv("APP_URL")}/${goConfig("routes.adgangsplatformen-service-proxy")}/fbi`
+}
+
+export const getAPServiceFetcherAuthheader = async (serviceType: TServiceType) => {
+  const serviceSettings = getApServiceSettings(serviceType)
+
+  if (serviceSettings?.useLibraryTokenAlways) {
+    const libraryToken = await getLibraryTokenCookieValue()
+    return libraryToken ? `Bearer ${libraryToken}` : null
+  }
+
+  return null
 }

--- a/lib/helpers/bearer-token.ts
+++ b/lib/helpers/bearer-token.ts
@@ -14,16 +14,15 @@ import { TUniloginTokenSet } from "../types/session"
 import { TServiceType, getApServiceSettings } from "./ap-service"
 import { getLibraryTokenCookieValue } from "./library-token"
 
-export const getBearerTokenServerSide = async (
-  serviceType: TServiceType,
-  session?: IronSession<TSessionData>
-) => {
+export const getBearerTokenServerSide = async (serviceType: TServiceType) => {
   const useLibraryToken = getApServiceSettings(serviceType)?.useLibraryTokenAlways ?? true
   const libraryToken = await getLibraryTokenCookieValue()
-  const userToken = session?.adgangsplatformenUserToken
   if (useLibraryToken && libraryToken) {
     return libraryToken
   }
+
+  const session = await getSession()
+  const userToken = session?.adgangsplatformenUserToken
 
   if (userToken) {
     return userToken
@@ -41,8 +40,7 @@ export const createServerQueryFn = async <TQuery, TVariables>(
   variables: TVariables,
   options?: RequestInit["headers"]
 ) => {
-  const session = await getSession()
-  const bearerToken = await getBearerTokenServerSide("fbi", session)
+  const bearerToken = await getBearerTokenServerSide("fbi")
 
   return fetcher(variables, { ...options, authorization: `Bearer ${bearerToken}` })
 }

--- a/lib/rest/cover-service-api/mutator/fetcher.ts
+++ b/lib/rest/cover-service-api/mutator/fetcher.ts
@@ -1,5 +1,4 @@
-import { getEnv } from "@/lib/config/env"
-import goConfig from "@/lib/config/goConfig"
+import { getAPServiceFetcherAuthheader, getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
 
 import { getRestServiceUrlWithParams } from "../../../fetchers/helper"
 
@@ -15,15 +14,12 @@ export const fetcher = async <ResponseType>({
   data?: BodyType<unknown>
   signal?: AbortSignal
 }) => {
-  const additionalHeaders = data?.headers === "object" ? (data?.headers as unknown as object) : {}
-
-  const headers = {
-    ...additionalHeaders,
-  }
-
+  const authHeader = await getAPServiceFetcherAuthheader("covers")
+  const headers = data?.headers === "object" ? (data?.headers as unknown as object) : {}
+  const baseUrl = getAPServiceFetcherBaseUrl("covers")
   const body = data ? JSON.stringify(data) : null
   const serviceUrl = getRestServiceUrlWithParams({
-    baseUrl: `${getEnv("APP_URL")}/${goConfig("routes.adgangsplatformen-service-proxy")}/covers`,
+    baseUrl,
     url,
     params,
   })
@@ -31,7 +27,10 @@ export const fetcher = async <ResponseType>({
   try {
     const response = await fetch(serviceUrl, {
       method,
-      headers,
+      headers: {
+        ...(authHeader ? { authorization: authHeader } : {}),
+        ...headers,
+      },
       body,
     })
 

--- a/lib/rest/fbs/mutator/fetcher.ts
+++ b/lib/rest/fbs/mutator/fetcher.ts
@@ -1,6 +1,5 @@
-import { getEnv } from "@/lib/config/env"
-import goConfig from "@/lib/config/goConfig"
 import { getRestServiceUrlWithParams } from "@/lib/fetchers/helper"
+import { getAPServiceFetcherAuthheader, getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
 
 export const fetcher = async <ResponseType>({
   url,
@@ -16,9 +15,11 @@ export const fetcher = async <ResponseType>({
   data?: BodyType<unknown>
   signal?: AbortSignal
 }) => {
+  const authHeader = await getAPServiceFetcherAuthheader("fbs")
+  const baseUrl = getAPServiceFetcherBaseUrl("fbs")
   const body = data ? JSON.stringify(data) : null
   const serviceUrl = getRestServiceUrlWithParams({
-    baseUrl: `${getEnv("APP_URL")}/${goConfig("routes.adgangsplatformen-service-proxy")}/fbs`,
+    baseUrl,
     url,
     params,
   })
@@ -27,6 +28,7 @@ export const fetcher = async <ResponseType>({
     const response = await fetch(serviceUrl, {
       method,
       headers: {
+        ...(authHeader ? { authorization: authHeader } : {}),
         ...headers,
       },
       body,

--- a/lib/rest/publizon/adapter/mutator/fetcher.ts
+++ b/lib/rest/publizon/adapter/mutator/fetcher.ts
@@ -1,6 +1,5 @@
-import { getEnv } from "@/lib/config/env"
-import goConfig from "@/lib/config/goConfig"
 import { getRestServiceUrlWithParams } from "@/lib/fetchers/helper"
+import { getAPServiceFetcherAuthheader, getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
 
 export const fetcher = async <ResponseType>({
   url,
@@ -16,9 +15,11 @@ export const fetcher = async <ResponseType>({
   data?: BodyType<unknown>
   signal?: AbortSignal
 }) => {
+  const authHeader = await getAPServiceFetcherAuthheader("pubhub-adapter")
+  const baseUrl = getAPServiceFetcherBaseUrl("pubhub-adapter")
   const body = data ? JSON.stringify(data) : null
   const serviceUrl = getRestServiceUrlWithParams({
-    baseUrl: `${getEnv("APP_URL")}/${goConfig("routes.adgangsplatformen-service-proxy")}/pubhub-adapter`,
+    baseUrl,
     url,
     params,
   })
@@ -27,6 +28,7 @@ export const fetcher = async <ResponseType>({
     const response = await fetch(serviceUrl, {
       method,
       headers: {
+        ...(authHeader ? { authorization: authHeader } : {}),
         ...headers,
       },
       body,


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-508

#### Description

This PR should be merged after [this one](https://github.com/danskernesdigitalebibliotek/dpl-go/pull/208) has been reviewed because it contains a lot of the same commits.

The main focus in this PR is to make sure that Adgangsplatform services that are not dependent on an authorized user (aka only uses library token) do NOT use the ap service proxy, because we never need to attach the user token server side.
Right now the cover service is a service that only needs the library token and therefor is not being proxied.

But this PR also introduces a function for resolving the auth header in the AP service fetchers, so it is done in a uniform way.
And this PR makes sure that it is always possible to override the fetch headers from outside the fetchers.

