### PR TITLE
Add support ID to profile page

### DIFF
--- a/__tests__/__snapshots__/pubhub.test.ts.snap
+++ b/__tests__/__snapshots__/pubhub.test.ts.snap
@@ -20,6 +20,7 @@ exports[`Pubhub local API > Returns same output from local & external GET /v1/us
   "userData": {
     "audiobookLoansRemaining": 0,
     "ebookLoansRemaining": 2,
+    "friendlyCardNumber": "T4EFB7",
     "totalAudioLoans": 0,
     "totalEbookLoans": 1,
     "totalLoans": 1,

--- a/app/pubhub/v1/user/loans/(lib)/schemas.ts
+++ b/app/pubhub/v1/user/loans/(lib)/schemas.ts
@@ -28,6 +28,7 @@ export const libraryUserOrderListSchema = z.object({
     }),
     data: z.object({
       orderitem: orderItemSchema.or(z.array(orderItemSchema)),
+      friendlycardnumber: z.string().optional(),
     }),
   }),
 })

--- a/app/pubhub/v1/user/loans/route.ts
+++ b/app/pubhub/v1/user/loans/route.ts
@@ -39,6 +39,7 @@ async function getLibraryUserOrder(request: NextRequest, context: { uniLoginUser
         // There is no direct data field from the SOAP service that gives the remaining amount of audiobooks
         audiobookLoansRemaining:
           Number(libraryData.maxloanpertimesound) - Number(libraryData.usertotalsoundloans),
+        friendlyCardNumber: orderListResponse.data.friendlycardnumber,
       },
     }
   })

--- a/app/user/profile/ProfilePageLayout.tsx
+++ b/app/user/profile/ProfilePageLayout.tsx
@@ -8,6 +8,7 @@ import { ButtonSkeleton } from "@/components/shared/button/Button"
 import { userIsAnonymous } from "@/lib/helpers/user"
 import { getSession } from "@/lib/session/session"
 
+import SupportId, { SupportIdSkeleton } from "./SupportId"
 import Username, { UsernameSkeleton } from "./Username"
 
 const ProfilePageLayout = async () => {
@@ -20,7 +21,7 @@ const ProfilePageLayout = async () => {
   return (
     <div className="content-container grid-go -mt-space-y w-full space-y-3">
       <div className="col-span-full flex flex-row flex-wrap">
-        <h1 className="text-typo-subtitle-sm mb-5 lg:w-full">Profile</h1>
+        <h1 className="text-typo-subtitle-sm mb-5 opacity-50 lg:w-full">Profile</h1>
         <Suspense fallback={<ButtonSkeleton size="sm" />}>
           <LogoutButton />
         </Suspense>
@@ -28,6 +29,9 @@ const ProfilePageLayout = async () => {
           <Username />
         </Suspense>
       </div>
+      <Suspense fallback={<SupportIdSkeleton />}>
+        <SupportId />
+      </Suspense>
       <Suspense fallback={<LoanSliderSkeleton />}>
         <UserLoans />
       </Suspense>

--- a/app/user/profile/ProfilePageLayout.tsx
+++ b/app/user/profile/ProfilePageLayout.tsx
@@ -21,7 +21,7 @@ const ProfilePageLayout = async () => {
   return (
     <div className="content-container grid-go -mt-space-y w-full space-y-3">
       <div className="col-span-full flex flex-row flex-wrap">
-        <h1 className="text-typo-subtitle-sm mb-5 opacity-50 lg:w-full">Profile</h1>
+        <h1 className="text-typo-subtitle-sm text-foreground/50 mb-5 lg:w-full">Profile</h1>
         <Suspense fallback={<ButtonSkeleton size="sm" />}>
           <LogoutButton />
         </Suspense>

--- a/app/user/profile/SupportId.tsx
+++ b/app/user/profile/SupportId.tsx
@@ -19,7 +19,11 @@ const SupportId = ({ className }: SupportIdProps) => {
   }
 
   return (
-    <div className={cn("text-typo-subtitle-sm col-span-full -mt-5 pb-5 opacity-50", className)}>
+    <div
+      className={cn(
+        "text-typo-subtitle-sm text-foreground/50 col-span-full -mt-5 pb-5",
+        className
+      )}>
       {`Support ID: ${data.userData.friendlyCardNumber}`}
     </div>
   )

--- a/app/user/profile/SupportId.tsx
+++ b/app/user/profile/SupportId.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { cn } from "@/lib/helpers/helper.cn"
+import useGetV1UserLoans from "@/lib/rest/publizon/useGetV1UserLoans"
+
+type SupportIdProps = {
+  className?: string
+}
+
+const SupportId = ({ className }: SupportIdProps) => {
+  const { data, isLoading } = useGetV1UserLoans()
+
+  if (isLoading) {
+    return <SupportIdSkeleton />
+  }
+
+  if (!data?.userData?.friendlyCardNumber) {
+    return null
+  }
+
+  return (
+    <div className={cn("text-typo-subtitle-sm col-span-full -mt-5 pb-5 opacity-50", className)}>
+      {`Support ID: ${data.userData.friendlyCardNumber}`}
+    </div>
+  )
+}
+
+export const SupportIdSkeleton = ({ className }: SupportIdProps) => (
+  <div
+    className={cn(
+      "bg-background-skeleton -mt-5 mb-5 h-5 w-52 animate-pulse rounded-full pb-5",
+      className
+    )}
+  />
+)
+
+export default SupportId


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-421

#### Description
This PR adds support ID for unilogin + bib users on the profile page.

#### Screenshot of the result
![image](https://github.com/user-attachments/assets/380401ae-8361-4762-a6e9-ac2f73a05644)

#### Additional comments or questions
-
