### PR TITLE
Solve weird cascade loading on front and search page

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -128,6 +128,12 @@ const fakeDrupalSessionRequestCookie = {
   value: "some-drupal-session-cookie-value",
 }
 
+const getNextRequestWithLibraryTokenCookie = () => {
+  const request = new NextRequest("http://localhost")
+  request.cookies.set(goConfig("library-token.cookie-name"), "hi-I-am-a-library-token")
+  return request
+}
+
 describe("Middleware", () => {
   afterEach(() => {
     vi.clearAllMocks()
@@ -136,6 +142,12 @@ describe("Middleware", () => {
   const sessions = getFakeSessions()
 
   it("can ensure that a library token is present if it is not already", async () => {
+    vi.spyOn(userTokenFunctions, "loadUserToken").mockResolvedValue(
+      await Promise.resolve({
+        token: "hi-I-am-a-dpl-cms-user-token",
+        expire: 363663636,
+      })
+    )
     vi.spyOn(libraryTokenFunctions, "loadLibraryToken").mockResolvedValueOnce(
       await Promise.resolve({
         token: "hi-I-am-a-library-token",
@@ -156,7 +168,7 @@ describe("Middleware", () => {
     )
     vi.spyOn(headersFunctions, "cookies").mockResolvedValue(
       Promise.resolve({
-        getAll: vi.fn(() => [fakeDrupalSessionRequestCookie]),
+        getAll: vi.fn(() => []),
         set: vi.fn(),
         get: vi
           .fn()
@@ -181,7 +193,7 @@ describe("Middleware", () => {
     const destroySessionSpy = vi
       .spyOn(sessionFunctions, "destroySession")
       .mockResolvedValue(Promise.resolve())
-    await middleware(new NextRequest("http://localhost"))
+    await middleware(getNextRequestWithLibraryTokenCookie())
     expect(destroySessionSpy).toHaveResolvedTimes(1)
   })
 
@@ -213,7 +225,7 @@ describe("Middleware", () => {
       })
     )
 
-    await middleware(new NextRequest("http://localhost"))
+    await middleware(getNextRequestWithLibraryTokenCookie())
 
     expect(saveAdgangsplatformenSessionSpy).toHaveResolvedTimes(1)
   })
@@ -240,7 +252,7 @@ describe("Middleware", () => {
       })
     )
 
-    await middleware(new NextRequest("http://localhost"))
+    await middleware(getNextRequestWithLibraryTokenCookie())
 
     expect(saveAdgangsplatformenSessionSpy).toHaveResolvedTimes(1)
   })
@@ -267,7 +279,7 @@ describe("Middleware", () => {
       })
     )
 
-    await middleware(new NextRequest("http://localhost"))
+    await middleware(getNextRequestWithLibraryTokenCookie())
 
     expect(saveAdgangsplatformenSessionSpy).toHaveResolvedTimes(0)
   })
@@ -301,7 +313,7 @@ describe("Middleware", () => {
       })
     )
 
-    await middleware(new NextRequest("http://localhost"))
+    await middleware(getNextRequestWithLibraryTokenCookie())
 
     expect(refreshUniloginTokensSpy).toHaveResolvedTimes(1)
   })
@@ -342,7 +354,7 @@ describe("Middleware", () => {
       .spyOn(sessionFunctions, "destroySession")
       .mockResolvedValue(Promise.resolve())
 
-    await middleware(new NextRequest("http://localhost"))
+    await middleware(getNextRequestWithLibraryTokenCookie())
 
     expect(destroySessionSpy).toHaveBeenCalledTimes(1)
   })
@@ -376,7 +388,7 @@ describe("Middleware", () => {
       })
     )
 
-    await middleware(new NextRequest("http://localhost"))
+    await middleware(getNextRequestWithLibraryTokenCookie())
 
     expect(destroySessionSpy).toHaveResolvedTimes(1)
   })

--- a/__tests__/pubhub.test.ts
+++ b/__tests__/pubhub.test.ts
@@ -6,8 +6,10 @@ import * as apiEndpoint from "@/app/pubhub/v1/user/loans/route"
 import * as sessionFunctions from "@/lib/session/session"
 import * as clientFunctions from "@/lib/soap/publizon/v2_7/generated/getlibraryuserorderlist/client"
 
+import { testSilently } from "./helpers"
+
 describe("Pubhub local API", () => {
-  it("Returns unauthorized for anonymous user at GET /v1/user/loans", async () => {
+  testSilently("Returns unauthorized for anonymous user at GET /v1/user/loans", async () => {
     await testApiHandler({
       // @ts-ignore
       appHandler: apiEndpoint,

--- a/app/ap-service/[[...slug]]/route.ts
+++ b/app/ap-service/[[...slug]]/route.ts
@@ -18,14 +18,20 @@ const getAuthHeader = async (request: NextRequest, serviceType: TServiceType) =>
   const userToken = session?.adgangsplatformenUserToken
   const libraryToken = session?.adgangsplatformenLibraryToken
 
+  // If the settings (apServiceSettings) indicate that we should always use the library token,
+  // we will use the library token if it exists.
+  // Eg. the cover service always uses the library token because it does not need the user context.
   if (useLibraryToken && libraryToken) {
     return `Bearer ${libraryToken}`
   }
 
+  // If we can load a user token we have an authenticated session,
+  // and the user token has precedence over the library token.
   if (userToken) {
     return `Bearer ${userToken}`
   }
 
+  // At last, if we have a library token (which we should always have) we will use that.
   if (libraryToken) {
     return `Bearer ${libraryToken}`
   }

--- a/app/user/profile/ProfilePageLayout.tsx
+++ b/app/user/profile/ProfilePageLayout.tsx
@@ -8,6 +8,7 @@ import { ButtonSkeleton } from "@/components/shared/button/Button"
 import { userIsAnonymous } from "@/lib/helpers/user"
 import { getSession } from "@/lib/session/session"
 
+import DebuggingSession from "./DebuggingSession"
 import Username, { UsernameSkeleton } from "./Username"
 
 const ProfilePageLayout = async () => {
@@ -31,6 +32,7 @@ const ProfilePageLayout = async () => {
       <Suspense fallback={<LoanSliderSkeleton />}>
         <UserLoans />
       </Suspense>
+      <DebuggingSession hideInProduction />
     </div>
   )
 }

--- a/app/work/[id]/page.tsx
+++ b/app/work/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query"
+import { cookies } from "next/headers"
 import React from "react"
 
 import WorkPageLayout from "@/components/pages/workPageLayout/WorkPageLayout"
@@ -9,14 +10,17 @@ import { createServerQueryFn } from "@/lib/helpers/bearer-token"
 async function Page(props: { params: Promise<{ id: string }> }) {
   const params = await props.params
   const { id } = params
+  const cookieStore = await cookies()
 
   const queryClient = getQueryClient()
-  const decodedWid = decodeURIComponent(id)
+  const workId = decodeURIComponent(id)
 
   await queryClient.prefetchQuery({
-    queryKey: useGetMaterialQuery.getKey({ wid: decodedWid }),
-    queryFn: await createServerQueryFn(useGetMaterialQuery.fetcher, {
-      wid: decodedWid,
+    queryKey: useGetMaterialQuery.getKey({ wid: workId }),
+    queryFn: await createServerQueryFn({
+      fetcher: useGetMaterialQuery.fetcher,
+      variables: { wid: workId },
+      cookieStore,
     }),
   })
 
@@ -24,7 +28,7 @@ async function Page(props: { params: Promise<{ id: string }> }) {
   const dehydratedState = dehydrate(queryClient)
   return (
     <HydrationBoundary state={dehydratedState}>
-      <WorkPageLayout workId={decodedWid} />
+      <WorkPageLayout workId={workId} />
     </HydrationBoundary>
   )
 }

--- a/components/pages/workPageLayout/WorkPageLayout.tsx
+++ b/components/pages/workPageLayout/WorkPageLayout.tsx
@@ -26,7 +26,7 @@ function WorkPageLayout({ workId }: { workId: string }) {
     useState<ManifestationWorkPageFragment>()
   const searchParams = useSearchParams()
 
-  if (!data || !data.work) {
+  if (!isLoading && (!data || !data.work)) {
     notFound()
   }
 
@@ -58,7 +58,7 @@ function WorkPageLayout({ workId }: { workId: string }) {
     )
   }
 
-  if (!work) {
+  if (!isLoading && !work) {
     return notFound()
   }
 
@@ -71,7 +71,7 @@ function WorkPageLayout({ workId }: { workId: string }) {
             work={work}
             selectedManifestation={selectedManifestation}
           />
-          <InfoBox work={data.work} selectedManifestation={selectedManifestation} />
+          <InfoBox work={work} selectedManifestation={selectedManifestation} />
           <InfoBoxDetails selectedManifestation={selectedManifestation} />
         </>
       )}

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -84,7 +84,7 @@ export const CoverPicture = ({
               height={imageHeight}
               width={imageWidth}
               sizes="100vw"
-              loading="lazy"
+              loading="eager"
               className={cn(
                 `shadow-cover-picture absolute inset-0 h-auto w-full overflow-hidden rounded-sm object-contain
                   transition-all duration-500 will-change-transform`,

--- a/lib/helpers/ap-service.ts
+++ b/lib/helpers/ap-service.ts
@@ -1,6 +1,5 @@
 import { getEnv } from "../config/env"
 import goConfig from "../config/goConfig"
-import { getLibraryTokenCookieValue } from "./library-token"
 
 const serviceSettings = goConfig("services.ap-services")
 export type TServiceType = keyof typeof serviceSettings
@@ -18,27 +17,5 @@ export const getApServiceUrl = (serviceType: TServiceType) => {
   return serviceSettings.url
 }
 
-export const getAPServiceFetcherBaseUrl = (serviceType: TServiceType) => {
-  const serviceSettings = getApServiceSettings(serviceType)
-  const serviceUrl = getApServiceUrl(serviceType)
-
-  // If we always use the library token,
-  // there is no need to use the Adangsplatformen service proxy.
-  // And we can use the service url directly.
-  if (serviceSettings?.useLibraryTokenAlways) {
-    return serviceUrl
-  }
-
-  return `${getEnv("APP_URL")}/${goConfig("routes.adgangsplatformen-service-proxy")}/${serviceType}`
-}
-
-export const getAPServiceFetcherAuthheader = async (serviceType: TServiceType) => {
-  const serviceSettings = getApServiceSettings(serviceType)
-
-  if (serviceSettings?.useLibraryTokenAlways) {
-    const libraryToken = await getLibraryTokenCookieValue()
-    return libraryToken ? `Bearer ${libraryToken}` : null
-  }
-
-  return null
-}
+export const getAPServiceFetcherBaseUrl = (serviceType: TServiceType) =>
+  `${getEnv("APP_URL")}/${goConfig("routes.adgangsplatformen-service-proxy")}/${serviceType}`

--- a/lib/helpers/library-token.ts
+++ b/lib/helpers/library-token.ts
@@ -1,5 +1,3 @@
-"use server"
-
 import { cookies } from "next/headers"
 import { z } from "zod"
 
@@ -10,12 +8,6 @@ import {
   GetAdgangsplatformenLibraryTokenQuery,
   useGetAdgangsplatformenLibraryTokenQuery,
 } from "../graphql/generated/dpl-cms/graphql"
-
-export const getLibraryTokenCookieValue = async () => {
-  const cookieStore = await cookies()
-  const cookie = cookieStore.get(goConfig("library-token.cookie-name"))
-  return cookie?.value
-}
 
 export const setLibraryTokenCookie = async (token: string, expires: Date) => {
   const cookieStore = await cookies()

--- a/lib/helpers/middleware.ts
+++ b/lib/helpers/middleware.ts
@@ -1,12 +1,11 @@
-import {
-  getLibraryTokenCookieValue,
-  loadLibraryToken,
-  setLibraryTokenCookie,
-} from "./library-token"
+import { NextRequest } from "next/server"
 
-export const ensureLibraryTokenExist = async () => {
-  const libraryTokenCookieValue = await getLibraryTokenCookieValue()
-  if (!libraryTokenCookieValue) {
+import goConfig from "../config/goConfig"
+import { loadLibraryToken, setLibraryTokenCookie } from "./library-token"
+
+export const ensureLibraryTokenExist = async (request: NextRequest) => {
+  const libraryToken = request.cookies.get(goConfig("library-token.cookie-name"))?.value
+  if (!libraryToken) {
     const libraryToken = await loadLibraryToken()
     const timestamp = libraryToken?.expire.timestamp
     const expires = timestamp ? new Date(timestamp * 1000) : false

--- a/lib/rest/cover-service-api/mutator/fetcher.ts
+++ b/lib/rest/cover-service-api/mutator/fetcher.ts
@@ -1,4 +1,4 @@
-import { getAPServiceFetcherAuthheader, getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
+import { getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
 
 import { getRestServiceUrlWithParams } from "../../../fetchers/helper"
 
@@ -14,7 +14,6 @@ export const fetcher = async <ResponseType>({
   data?: BodyType<unknown>
   signal?: AbortSignal
 }) => {
-  const authHeader = await getAPServiceFetcherAuthheader("covers")
   const headers = data?.headers === "object" ? (data?.headers as unknown as object) : {}
   const baseUrl = getAPServiceFetcherBaseUrl("covers")
   const body = data ? JSON.stringify(data) : null
@@ -28,7 +27,6 @@ export const fetcher = async <ResponseType>({
     const response = await fetch(serviceUrl, {
       method,
       headers: {
-        ...(authHeader ? { authorization: authHeader } : {}),
         ...headers,
       },
       body,

--- a/lib/rest/fbs/mutator/fetcher.ts
+++ b/lib/rest/fbs/mutator/fetcher.ts
@@ -1,5 +1,5 @@
 import { getRestServiceUrlWithParams } from "@/lib/fetchers/helper"
-import { getAPServiceFetcherAuthheader, getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
+import { getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
 
 export const fetcher = async <ResponseType>({
   url,
@@ -15,7 +15,6 @@ export const fetcher = async <ResponseType>({
   data?: BodyType<unknown>
   signal?: AbortSignal
 }) => {
-  const authHeader = await getAPServiceFetcherAuthheader("fbs")
   const baseUrl = getAPServiceFetcherBaseUrl("fbs")
   const body = data ? JSON.stringify(data) : null
   const serviceUrl = getRestServiceUrlWithParams({
@@ -28,7 +27,6 @@ export const fetcher = async <ResponseType>({
     const response = await fetch(serviceUrl, {
       method,
       headers: {
-        ...(authHeader ? { authorization: authHeader } : {}),
         ...headers,
       },
       body,

--- a/lib/rest/publizon/adapter/mutator/fetcher.ts
+++ b/lib/rest/publizon/adapter/mutator/fetcher.ts
@@ -1,5 +1,5 @@
 import { getRestServiceUrlWithParams } from "@/lib/fetchers/helper"
-import { getAPServiceFetcherAuthheader, getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
+import { getAPServiceFetcherBaseUrl } from "@/lib/helpers/ap-service"
 
 export const fetcher = async <ResponseType>({
   url,
@@ -15,7 +15,6 @@ export const fetcher = async <ResponseType>({
   data?: BodyType<unknown>
   signal?: AbortSignal
 }) => {
-  const authHeader = await getAPServiceFetcherAuthheader("pubhub-adapter")
   const baseUrl = getAPServiceFetcherBaseUrl("pubhub-adapter")
   const body = data ? JSON.stringify(data) : null
   const serviceUrl = getRestServiceUrlWithParams({
@@ -28,7 +27,6 @@ export const fetcher = async <ResponseType>({
     const response = await fetch(serviceUrl, {
       method,
       headers: {
-        ...(authHeader ? { authorization: authHeader } : {}),
         ...headers,
       },
       body,

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,8 +24,9 @@ export async function middleware(request: NextRequest) {
       headers: requestHeaders,
     },
   })
+
   // Make sure we have a library token cookie.
-  await ensureLibraryTokenExist()
+  await ensureLibraryTokenExist(request)
 
   const session = await getSession({ request, response })
 
@@ -67,7 +68,6 @@ export async function middleware(request: NextRequest) {
     const config = await getUniloginClientConfig()
     if (config) {
       refreshUniloginTokens(session, config)
-      return response
     }
   }
 
@@ -83,6 +83,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      */
-    "/((?!auth|_next|favicon.ico|favicon-*|sitemap.xml|robots.txt|site.webmanifest).*)",
+    "/((?!auth|ap-service|_next|favicon.ico|favicon-*|sitemap.xml|robots.txt|site.webmanifest).*)",
   ],
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-563

#### Description

The loading flow on the front page and on the search page was slow and seemed like it was waiting for requests to be fulfilled.
I found out that the functionality to get the librarytoken had turned into a server action and was called over and over again.

The architecture around the library token has now been restructured. It is still saved as a cookie so we can take advantage of the general principle of cookies expiring in browsers. But the value from the cookie is retrieved from the `getSession` function that is now a singe entrypoint for getting both the user and the library token. It means we do not have to struggle wit cookie fetching in a mixed client/server environment and we handle the user library token lookup in the same manner.

Also I excluded `ap-service` from the middleware to speed up the requests. That means the token maintenance functionality is being done on other routes - like the initial page load.

