### PR TITLE
Goodbye /go cms url prefix for go CMS content

### DIFF
--- a/lib/helpers/dpl-cms-content.ts
+++ b/lib/helpers/dpl-cms-content.ts
@@ -2,9 +2,9 @@ type TDplCmsContentType = "article" | "page" | "category"
 
 export const getContentQueryPath = (path: string, type: TDplCmsContentType) => {
   const pathMap = {
-    article: `go/artikel/${path}`,
-    page: `go/${path}`,
-    category: `go/kategori/${path}`,
+    article: `artikel/${path}`,
+    page: `${path}`,
+    category: `kategori/${path}`,
   }
 
   return pathMap[type] ?? path


### PR DESCRIPTION


#### Description

We decided to remove it again
