### PR TITLE
The __typename of the fetched entity has been added

### DIFF
--- a/cypress/factories/dpl-cms/getPageByPathQuery/go-frontpage.ts
+++ b/cypress/factories/dpl-cms/getPageByPathQuery/go-frontpage.ts
@@ -8,6 +8,7 @@ export default Factory.define<GetPageByPathQuery>(() => {
       __typename: "RouteInternal",
       url: "https://go-demo.cms-demo.dpl-cms.dplplat01.dpl.reload.dk/go-frontpage",
       entity: {
+        __typename: "NodeGoPage",
         paragraphs: [
           {
             __typename: "ParagraphGoVideoBundleAutomatic",


### PR DESCRIPTION
Without this our tsc check in CI thrwos an error which prevents the `build source` workflow to build the app.
