### PR TITLE
Added Typescript compilation workflow

### DIFF
--- a/.github/workflows/typescript-compilation.yml
+++ b/.github/workflows/typescript-compilation.yml
@@ -1,0 +1,31 @@
+name: Typescript compilation check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Make sure the actual branch is checked out when running on pull requests.
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0 # 👈 Required to retrieve git history
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Check Typescript compilation
+        run: yarn tsc --noEmit


### PR DESCRIPTION
We are currently not checking for TS compilation in CI, which has caused an undiscovered error to make its way into main.
This PR adds a simple workflow to run `yarn tsc` for any new code in branches.
