### PR TITLE
Move some configuration to dpl-cms

### DIFF
--- a/app/(routes)/auth/callback/unilogin/helper.ts
+++ b/app/(routes)/auth/callback/unilogin/helper.ts
@@ -16,7 +16,7 @@ export const isUniloginUserAuthorizedToLogIn = async (
     return false
   }
   const institution = await getInstitutionRequest(institutionId)
-  const municipalityId = getLibraryMunicipalityId()
+  const municipalityId = await getLibraryMunicipalityId()
   // If the institution is DDF we are using a test user and therefore allow access
   if (institution.instnr === "A04441") {
     return true

--- a/app/(routes)/auth/callback/unilogin/requests.ts
+++ b/app/(routes)/auth/callback/unilogin/requests.ts
@@ -7,7 +7,11 @@ export const getInstitutionRequest = async (institutionId: string) => {
   const client = await createClientAsync("./lib/soap/unilogin/wsiinst-v5/wsdl/ws.wsdl", {
     forceSoap12Headers: true,
   })
-  const { username, password } = getUniloginWsCredentials()
+  const { username, password } = await getUniloginWsCredentials()
+  if (!username || !password) {
+    throw new Error("Missing Unilogin credentials")
+  }
+
   const [response] = await client.hentInstitutionAsync({
     wsBrugerid: username,
     wsPassword: password,

--- a/app/(routes)/pubhub/v1/library/profile/(lib)/requests.ts
+++ b/app/(routes)/pubhub/v1/library/profile/(lib)/requests.ts
@@ -7,9 +7,9 @@ export const getLibraryProfileRequest = async () => {
   const client = await createClientAsyncGetLibraryProfile(
     "./lib/soap/publizon/v2_7/wsdl/getlibraryinfo.wsdl"
   )
-
+  const publizonServiceParameters = await getPublizonServiceParameters()
   const [response] = await client.GetLibraryProfileAsync({
-    ...getPublizonServiceParameters(),
+    ...publizonServiceParameters,
   })
   return response.GetLibraryProfileResult as TGetLibraryProfile
 }

--- a/app/(routes)/pubhub/v1/products/[identifier]/(lib)/requests.ts
+++ b/app/(routes)/pubhub/v1/products/[identifier]/(lib)/requests.ts
@@ -10,8 +10,10 @@ export const getProductsRequest = async (uniLoginUserInfo: TUserInfo, identifier
   if (!institutionid) {
     throw new Error("Institution id not found")
   }
+  const publizonServiceParameters = await getPublizonServiceParameters()
+
   const [response] = await client.GetProductAsync({
-    ...getPublizonServiceParameters(),
+    ...publizonServiceParameters,
     ebookid: identifier,
   })
 

--- a/app/(routes)/pubhub/v1/user/loans/(lib)/requests.ts
+++ b/app/(routes)/pubhub/v1/user/loans/(lib)/requests.ts
@@ -30,11 +30,13 @@ const defaultData: TLibraryUserOrderList = {
 }
 
 export const getLibraryUserOrderListRequest = async (uniLoginUserInfo: TUserInfo) => {
+  const publizonServiceParameters = await getPublizonServiceParameters()
+
   const client = await createClientAsync(
     "./lib/soap/publizon/v2_7/wsdl/getlibraryuserorderlist.wsdl"
   )
   const [libraryUserResponse] = await client.GetLibraryUserOrderListAsync({
-    ...getPublizonServiceParameters(),
+    ...publizonServiceParameters,
     cardnumber: uniLoginUserInfo.uniid,
   })
 
@@ -49,7 +51,7 @@ export const getLibraryUserOrderListRequest = async (uniLoginUserInfo: TUserInfo
       "./lib/soap/publizon/v2_7/wsdl/getfriendlycardnumber.wsdl"
     )
     const [friendlyCardNumberResponse] = await friendlyCardNumberClient.GetFriendlyCardnumberAsync({
-      ...getPublizonServiceParameters(),
+      ...publizonServiceParameters,
       cardnumber: uniLoginUserInfo.uniid,
     })
 

--- a/app/(routes)/pubhub/v1/user/loans/[identifier]/(lib)/requests.ts
+++ b/app/(routes)/pubhub/v1/user/loans/[identifier]/(lib)/requests.ts
@@ -5,7 +5,7 @@ import { createClientAsync as createClientAsyncCreateLoan } from "@/lib/soap/pub
 
 export const createLoanRequest = async (uniLoginUserInfo: TUserInfo, ebookId: string) => {
   const client = await createClientAsyncCreateLoan("./lib/soap/publizon/v2_7/wsdl/createloan.wsdl")
-  const { clientid, retailerid, retailerkeycode } = getPublizonServiceParameters()
+  const { clientid, retailerid, retailerkeycode } = await getPublizonServiceParameters()
   const institutionid = uniLoginUserInfo.institution_ids[0]
   if (!institutionid) {
     throw new Error("Institution id not found")

--- a/lib/config/dpl-cms/configSchemas.ts
+++ b/lib/config/dpl-cms/configSchemas.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const publicConfigSchema = z.object({
+  loginUrls: z.object({
+    adgangsplatformen: z.string().nullable(),
+  }),
+  logoutUrls: z.object({
+    adgangsplatformen: z.string().nullable(),
+  }),
+  libraryInfo: z.object({
+    name: z.string().nullable(),
+  }),
+  unilogin: z.object({
+    municipalityId: z.string().nullable(),
+  }),
+})
+
+export const privateConfigSchema = z.object({
+  unilogin: z.object({
+    clientSecret: z.string().nullable(),
+    webServiceUsername: z.string().nullable(),
+    webServicePassword: z.string().nullable(),
+    pubHubRetailerKeyCode: z.string().nullable(),
+  }),
+})
+
+export type TDplCmsPublicConfig = z.infer<typeof publicConfigSchema>
+export type TDplCmsPrivateConfig = z.infer<typeof privateConfigSchema>

--- a/lib/config/dpl-cms/dplCmsConfig.ts
+++ b/lib/config/dpl-cms/dplCmsConfig.ts
@@ -1,5 +1,4 @@
 import { unstable_cacheLife as cacheLife } from "next/cache"
-import { z } from "zod"
 
 import {
   useGetDplCmsPrivateConfigurationQuery,
@@ -7,66 +6,78 @@ import {
 } from "@/lib/graphql/generated/dpl-cms/graphql"
 
 import { getServerEnv } from "../env"
+import { privateConfigSchema, publicConfigSchema } from "./configSchemas"
 
 const queryDplCmsPrivateConfig = async () => {
   const { goConfiguration } = await useGetDplCmsPrivateConfigurationQuery.fetcher(undefined)()
   return goConfiguration?.private ?? null
 }
 
-export const getDplCmsPrivateUniloginConfig = async () => {
-  const wellknownUrl = getServerEnv("UNILOGIN_WELLKNOWN_URL")
-  const clientId = getServerEnv("UNILOGIN_CLIENT_ID")
-  const clientSecret = getServerEnv("UNILOGIN_CLIENT_SECRET")
+const queryDplCmsPublicConfig = async () => {
+  const { goConfiguration } = await useGetDplCmsPublicConfigurationQuery.fetcher(undefined)()
+  return goConfiguration?.public ?? null
+}
 
-  const configEnv = {
-    wellknownUrl,
-    clientId,
-    clientSecret,
-  }
+const getDplCmsPrivateConfigData = async () => {
+  "use cache"
+  // Automatically expires after a few minutes
+  // @todo Implement cache tags when we are sure that the cms is revalidating go configuration properly.
+  cacheLife("minutes")
 
-  let configAPI = {}
-  // If we are running in test mode, we don't want to query the DPL CMS config
-  const config = await queryDplCmsPrivateConfig()
-  if (config?.unilogin) {
-    configAPI = {
-      wellknownUrl: config.unilogin.unilogin_api_wellknown_url ?? null,
-      clientId: config.unilogin.unilogin_api_client_id ?? null,
-      clientSecret: config.unilogin.unilogin_api_client_secret ?? null,
+  try {
+    const data = await queryDplCmsPrivateConfig()
+    return privateConfigSchema.parse(data)
+  } catch {
+    return {
+      unilogin: {
+        clientSecret: null,
+        webServiceUsername: null,
+        webServicePassword: null,
+        pubHubRetailerKeyCode: null,
+      },
     }
-  }
-
-  return {
-    ...configAPI,
-    ...configEnv,
   }
 }
 
-const dplCmsPublicConfigSchema = z.object({
-  public: z.object({
-    loginUrls: z.object({
-      adgangsplatformen: z.string().nullable(),
-    }),
-    logoutUrls: z.object({
-      adgangsplatformen: z.string().nullable(),
-    }),
-    libraryInfo: z.object({
-      name: z.string().nullable(),
-    }),
-  }),
-})
+export const getDplCmsPrivateConfig = async () => {
+  const data = await getDplCmsPrivateConfigData()
 
-export type TDplCmsPublicConfig = z.infer<typeof dplCmsPublicConfigSchema>["public"]
+  const uniLoginConfigEnv = {
+    ...(getServerEnv("UNILOGIN_CLIENT_SECRET")
+      ? { clientSecret: getServerEnv("UNILOGIN_CLIENT_SECRET") }
+      : {}),
+    ...(getServerEnv("UNLILOGIN_SERVICES_WS_USER")
+      ? { webServiceUsername: getServerEnv("UNLILOGIN_SERVICES_WS_USER") }
+      : {}),
+    ...(getServerEnv("UNLILOGIN_SERVICES_WS_PASSWORD")
+      ? { webServicePassword: getServerEnv("UNLILOGIN_SERVICES_WS_PASSWORD") }
+      : {}),
+    ...(getServerEnv("UNLILOGIN_PUBHUB_RETAILER_KEY_CODE")
+      ? { pubHubRetailerKeyCode: getServerEnv("UNLILOGIN_PUBHUB_RETAILER_KEY_CODE") }
+      : {}),
+  }
 
-export const getDplCmsPublicConfig = async () => {
+  const unilogin = {
+    ...data.unilogin,
+    ...uniLoginConfigEnv,
+  }
+  return {
+    ...data,
+    unilogin,
+  }
+}
+
+const getDplCmsPublicConfigData = async () => {
   "use cache"
   // Automatically expires after a few minutes
+  // @todo Implement cache tags when we are sure that the cms is revalidating go configuration properly.
   cacheLife("minutes")
 
-  // @todo Implement cache tags when we are sure that the cms is revalidating go configuration properly.
   try {
-    const data = await useGetDplCmsPublicConfigurationQuery.fetcher(undefined)()
-    return dplCmsPublicConfigSchema.parse(data.goConfiguration).public
+    const data = await queryDplCmsPublicConfig()
+    return publicConfigSchema.parse(data)
   } catch {
+    console.error("Failed to parse DPL CMS public config")
     return {
       loginUrls: {
         adgangsplatformen: null,
@@ -77,6 +88,19 @@ export const getDplCmsPublicConfig = async () => {
       libraryInfo: {
         name: null,
       },
+      unilogin: {
+        municipalityId: null,
+      },
     }
   }
+}
+
+export const getDplCmsPublicConfig = async () => {
+  const data = await getDplCmsPublicConfigData()
+  const envMunicipalityId = getServerEnv("UNILOGIN_MUNICIPALITY_ID")
+  if (envMunicipalityId) {
+    data.unilogin.municipalityId = envMunicipalityId
+  }
+
+  return data
 }

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -61,12 +61,12 @@ const EnvServerSchema = z.object({
       z.literal(PHASE_TEST),
     ])
     .optional(),
-  UNILOGIN_MUNICIPALITY_ID: z.string(),
+  UNILOGIN_MUNICIPALITY_ID: z.string().optional(),
   UNLILOGIN_PUBHUB_CLIENT_ID: z.string(),
   UNLILOGIN_PUBHUB_RETAILER_ID: z.string(),
-  UNLILOGIN_PUBHUB_RETAILER_KEY_CODE: z.string(),
-  UNLILOGIN_SERVICES_WS_PASSWORD: z.string(),
-  UNLILOGIN_SERVICES_WS_USER: z.string(),
+  UNLILOGIN_PUBHUB_RETAILER_KEY_CODE: z.string().optional(),
+  UNLILOGIN_SERVICES_WS_PASSWORD: z.string().optional(),
+  UNLILOGIN_SERVICES_WS_USER: z.string().optional(),
   // Is fetched from dpl-cms, but can be overridden by env vars
   UNILOGIN_CLIENT_ID: z.string().optional(),
   UNILOGIN_CLIENT_SECRET: z.string().optional(),

--- a/lib/graphql/generated/dpl-cms/graphql.ts
+++ b/lib/graphql/generated/dpl-cms/graphql.ts
@@ -42,7 +42,7 @@ export type Address = {
   sortingCode?: Maybe<Scalars['String']['output']>;
 };
 
-/** Kommune. */
+/** Address country. */
 export type AddressCountry = {
   __typename?: 'AddressCountry';
   /** The code of the country. */
@@ -85,10 +85,10 @@ export type BetweenStringInput = {
   min?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** En CQL søgestreng. */
+/** A CQL search string. */
 export type CqlSearch = {
   __typename?: 'CQLSearch';
-  /** CQL søgestrengen. */
+  /** The CQL search string. */
   value?: Maybe<Scalars['String']['output']>;
 };
 
@@ -133,11 +133,11 @@ export type File = {
   __typename?: 'File';
   /** The description of the file. */
   description?: Maybe<Scalars['String']['output']>;
-  /** Filens mime-type. */
+  /** The mime type of the file. */
   mime?: Maybe<Scalars['String']['output']>;
-  /** Filens navn. */
+  /** The name of the file. */
   name?: Maybe<Scalars['String']['output']>;
-  /** Filens størrelse i bytes. */
+  /** The size of the file in bytes. */
   size: Scalars['Int']['output'];
   /** The URL of the file. */
   url: Scalars['String']['output'];
@@ -146,7 +146,7 @@ export type File = {
 /** Result for view go_categories display go_categories. */
 export type GoCategoriesResult = View & {
   __typename?: 'GoCategoriesResult';
-  /** Viewets beskrivelse. */
+  /** The description of the view. */
   description?: Maybe<Scalars['String']['output']>;
   /** The machine name of the display. */
   display: Scalars['String']['output'];
@@ -172,7 +172,7 @@ export type GoConfiguration = {
 
 export type GoConfigurationPrivate = {
   __typename?: 'GoConfigurationPrivate';
-  unilogin?: Maybe<UniloginConfiguration>;
+  unilogin?: Maybe<UniloginConfigurationPrivate>;
 };
 
 export type GoConfigurationPublic = {
@@ -180,6 +180,7 @@ export type GoConfigurationPublic = {
   libraryInfo?: Maybe<GoLibraryInfo>;
   loginUrls?: Maybe<GoLoginUrls>;
   logoutUrls?: Maybe<GoLogoutUrls>;
+  unilogin?: Maybe<UniloginConfigurationPublic>;
 };
 
 export type GoLibraryInfo = {
@@ -227,20 +228,21 @@ export type Language = {
   __typename?: 'Language';
   /** The language direction. */
   direction?: Maybe<Scalars['String']['output']>;
-  /** Sprogkoden. */
+  /** The language code. */
   id?: Maybe<Scalars['ID']['output']>;
-  /** Sprogets navn. */
+  /** The language name. */
   name?: Maybe<Scalars['String']['output']>;
 };
 
 /** A link. */
 export type Link = {
   __typename?: 'Link';
+  id?: Maybe<Scalars['String']['output']>;
   /** Whether the link is internal to this website. */
   internal: Scalars['Boolean']['output'];
-  /** Linkets titel */
+  /** The title of the link. */
   title?: Maybe<Scalars['String']['output']>;
-  /** Linkets URL */
+  /** The URL of the link. */
   url?: Maybe<Scalars['String']['output']>;
 };
 
@@ -255,13 +257,13 @@ export type MediaAudio = MediaInterface & {
   id: Scalars['ID']['output'];
   /** Language */
   langcode: Language;
-  /** Lydfil */
+  /** Audio file */
   mediaAudioFile: File;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -276,20 +278,20 @@ export type MediaDocument = MediaInterface & {
   id: Scalars['ID']['output'];
   /** Language */
   langcode: Language;
-  /** Fil */
+  /** File */
   mediaFile: File;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
 /** Entity type media. */
 export type MediaImage = MediaInterface & {
   __typename?: 'MediaImage';
-  /** Bruges til fotokreditering og info om copyright. Vises som regel ved siden af billedet. */
+  /** Used for public credit and copyright information. Will usually be displayed along with the media. */
   byline?: Maybe<Scalars['String']['output']>;
   /** The time the media item was last edited. */
   changed: DateTime;
@@ -300,18 +302,17 @@ export type MediaImage = MediaInterface & {
   /** Language */
   langcode: Language;
   /**
-   * Du kan indstille et fokuspunkt ved at klikke på forhåndsvisningen af
-   * billedet og flytte det hvide mål.<br /><br />Ved at indstille et fokuspunkt
-   * fortæller du systemet, hvilken del af billedet der skal være i fokus, når
-   * det beskæres.<br /><br />Brug funktionen "forhåndsvisning" til at se,
-   * hvordan dit billede vil blive beskåret på tværs af billedstil.
+   * You can set a focal point, by clicking on the preview on the image, moving the
+   * white target.<br /><br />By setting a focal point, you tell the system which
+   * part of the image to keep in focus when it gets cropped.<br /><br />Use the
+   * "preview" function, to see how your image will be cropped across image styles.
    */
   mediaImage: Image;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -325,11 +326,11 @@ export type MediaInterface = {
   id: Scalars['ID']['output'];
   /** Language */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -347,13 +348,13 @@ export type MediaVideo = MediaInterface & {
   id: Scalars['ID']['output'];
   /** Language */
   langcode: Language;
-  /** URL til video */
+  /** Remote video URL */
   mediaOembedVideo: Scalars['String']['output'];
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -370,11 +371,11 @@ export type MediaVideotool = MediaInterface & {
   langcode: Language;
   /** VideoTool URL */
   mediaVideotool: Scalars['String']['output'];
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -385,21 +386,21 @@ export type Mutation = {
   _: Scalars['Boolean']['output'];
 };
 
-/** Brug artikler til nyhedspræget indhold med en begrænset levetid. */
+/** Use articles for news-worthy content, that does not get updated regularly. */
 export type NodeArticle = NodeInterface & {
   __typename?: 'NodeArticle';
-  /** Bibliotek */
+  /** Branch */
   branch?: Maybe<NodeUnion>;
   /**
-   * Oplys en canonical URL hvis indholdet i artiklen er kopieret fra en anden
-   * hjemmeside (fx kopieret fra et andet biblioteks hjemmeside). Dette hjælper
-   * med at signalere til søgemaskiner at kilden til indholdet er den
-   * specificerede side, og sikrer at den originale kilde krediteres.
+   * Please provide a canonical URL if this content has been duplicated from other
+   * websites. This helps signal to search engines that the preferred source of
+   * this content is the specified canonical URL, preventing potential duplicate
+   * content issues and ensuring proper attribution to the original source.
    */
   canonicalUrl?: Maybe<Link>;
-  /** Kategorier */
+  /** Categories */
   categories?: Maybe<TermUnion>;
-  /** Tidspunktet hvor indholdselementet sidst blev redigeret. */
+  /** The time that the node was last edited. */
   changed: DateTime;
   /** The date and time that the content was created. */
   created: DateTime;
@@ -407,74 +408,75 @@ export type NodeArticle = NodeInterface & {
   id: Scalars['ID']['output'];
   /** Language */
   langcode: Language;
-  /** Overskriv forfatter */
+  /** Override author */
   overrideAuthor?: Maybe<Scalars['String']['output']>;
   /** Paragraphs */
   paragraphs?: Maybe<Array<ParagraphUnion>>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Forfremmet til forside */
+  /** Promoted to front page */
   promote: Scalars['Boolean']['output'];
-  /** Udgivelsesdato */
-  publicationDate: DateTime;
-  /**
-   * Som standard er forfatteren sat til den Drupal-bruger, der ejer indholdet.<br
-   * /><br />Hvis du ønsker at tilsidesætte dette med din egen tekst, kan du
-   */
-  showOverrideAuthor?: Maybe<Scalars['Boolean']['output']>;
-  /** Publiceret */
-  status: Scalars['Boolean']['output'];
-  /** Klæbrig */
-  sticky: Scalars['Boolean']['output'];
-  /** Manchet */
-  subtitle?: Maybe<Scalars['String']['output']>;
-  /** Tags */
-  tags?: Maybe<Array<TermUnion>>;
-  /**
-   * Teaserfelterne bruges til cards som blikfang for indholdet. Hvis der ikke er
-   * valgt et teaserbillede, vil teksten vises i stedet.
-   */
-  teaserImage?: Maybe<MediaUnion>;
-  /** Teasertekst */
-  teaserText?: Maybe<Scalars['String']['output']>;
-  /** Titel */
-  title: Scalars['String']['output'];
-  url: Scalars['String']['output'];
-};
-
-/** Brug GO-artikler til nyhedsværdigt indhold, der ikke bliver opdateret regelmæssigt. */
-export type NodeGoArticle = NodeInterface & {
-  __typename?: 'NodeGoArticle';
-  /** Tidspunktet hvor indholdselementet sidst blev redigeret. */
-  changed: DateTime;
-  /** The date and time that the content was created. */
-  created: DateTime;
-  /** Billede */
-  goArticleImage?: Maybe<MediaUnion>;
-  /** The Universally Unique IDentifier (UUID). */
-  id: Scalars['ID']['output'];
-  /** Language */
-  langcode: Language;
-  /** Overskriv forfatter */
-  overrideAuthor?: Maybe<Scalars['String']['output']>;
-  /** Paragraphs */
-  paragraphs?: Maybe<Array<ParagraphUnion>>;
-  /** Alternativ URL */
-  path?: Maybe<Scalars['String']['output']>;
-  /** Forfremmet til forside */
-  promote: Scalars['Boolean']['output'];
-  /** Publiceringsdato */
+  /** Publication date */
   publicationDate: DateTime;
   /**
    * By default, the author is set to the Drupal user that owns the content.<br
    * /><br />If you want to override this, with a manual text, you can check this.
    */
   showOverrideAuthor?: Maybe<Scalars['Boolean']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Klæbrig */
+  /** Sticky at top of lists */
   sticky: Scalars['Boolean']['output'];
-  /** Undertekst */
+  /** Subtitle */
+  subtitle?: Maybe<Scalars['String']['output']>;
+  /** Tags */
+  tags?: Maybe<Array<TermUnion>>;
+  /**
+   * The teaser fields are used for the card of display.<br />If no image has been
+   * selected, the text will be shown instead:<br /><br /><img
+   * src="/themes/custom/novel/images/teaser-text-image.jpg" /><br /><br /><hr/>
+   */
+  teaserImage?: Maybe<MediaUnion>;
+  /** Teaser text */
+  teaserText?: Maybe<Scalars['String']['output']>;
+  /** Title */
+  title: Scalars['String']['output'];
+  url: Scalars['String']['output'];
+};
+
+/** Use Go articles for news-worthy content, that does not get updated regularly. */
+export type NodeGoArticle = NodeInterface & {
+  __typename?: 'NodeGoArticle';
+  /** The time that the node was last edited. */
+  changed: DateTime;
+  /** The date and time that the content was created. */
+  created: DateTime;
+  /** Image */
+  goArticleImage?: Maybe<MediaUnion>;
+  /** The Universally Unique IDentifier (UUID). */
+  id: Scalars['ID']['output'];
+  /** Language */
+  langcode: Language;
+  /** Override author */
+  overrideAuthor?: Maybe<Scalars['String']['output']>;
+  /** Paragraphs */
+  paragraphs?: Maybe<Array<ParagraphUnion>>;
+  /** URL alias */
+  path?: Maybe<Scalars['String']['output']>;
+  /** Promoted to front page */
+  promote: Scalars['Boolean']['output'];
+  /** Publication date */
+  publicationDate: DateTime;
+  /**
+   * By default, the author is set to the Drupal user that owns the content.<br
+   * /><br />If you want to override this, with a manual text, you can check this.
+   */
+  showOverrideAuthor?: Maybe<Scalars['Boolean']['output']>;
+  /** Published */
+  status: Scalars['Boolean']['output'];
+  /** Sticky at top of lists */
+  sticky: Scalars['Boolean']['output'];
+  /** Subtitle */
   subtitle?: Maybe<Scalars['String']['output']>;
   /**
    * The teaser fields are used for the card of display.<br />If no image has been
@@ -482,9 +484,9 @@ export type NodeGoArticle = NodeInterface & {
    * src="/themes/custom/novel/images/teaser-text-image.jpg" /><br /><br /><hr/>
    */
   teaserImage: MediaUnion;
-  /** Teaser tekst */
+  /** Teaser text */
   teaserText?: Maybe<Scalars['String']['output']>;
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
   url: Scalars['String']['output'];
 };
@@ -501,7 +503,7 @@ export type NodeGoCategory = NodeInterface & {
   categoryMenuSound?: Maybe<MediaUnion>;
   /** The category title will be shown in the category menu as part of this category's menu element. */
   categoryMenuTitle: Scalars['String']['output'];
-  /** Tidspunktet hvor indholdselementet sidst blev redigeret. */
+  /** The time that the node was last edited. */
   changed: DateTime;
   /** The date and time that the content was created. */
   created: DateTime;
@@ -513,28 +515,29 @@ export type NodeGoCategory = NodeInterface & {
   langcode: Language;
   /** Paragraphs */
   paragraphs?: Maybe<Array<ParagraphUnion>>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Forfremmet til forside */
+  /** Promoted to front page */
   promote: Scalars['Boolean']['output'];
-  /** Publiceringsdato */
+  /** Publication date */
   publicationDate: DateTime;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Klæbrig */
+  /** Sticky at top of lists */
   sticky: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
   url: Scalars['String']['output'];
 };
 
 /**
- * GO-sider bliver brugt til forskellige typer for indhold, som ikke tilhører
- * hverken en artikel-side eller en kategori-side. Fx forsiden, informationssider
+ * GO pages will be used for various types of content, which does not belong to
+ * either an article page or an category page. Some examples could be the
+ * frontpage, info pages, etc.
  */
 export type NodeGoPage = NodeInterface & {
   __typename?: 'NodeGoPage';
-  /** Tidspunktet hvor indholdselementet sidst blev redigeret. */
+  /** The time that the node was last edited. */
   changed: DateTime;
   /** The date and time that the content was created. */
   created: DateTime;
@@ -542,26 +545,26 @@ export type NodeGoPage = NodeInterface & {
   id: Scalars['ID']['output'];
   /** Language */
   langcode: Language;
-  /** Paragraffer */
+  /** Paragraphs */
   paragraphs?: Maybe<Array<ParagraphUnion>>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Forfremmet til forside */
+  /** Promoted to front page */
   promote: Scalars['Boolean']['output'];
-  /** Publikationsdato */
+  /** Publication date */
   publicationDate: DateTime;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Klæbrig */
+  /** Sticky at top of lists */
   sticky: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
   url: Scalars['String']['output'];
 };
 
 /** Entity type node. */
 export type NodeInterface = {
-  /** Tidspunktet hvor indholdselementet sidst blev redigeret. */
+  /** The time that the node was last edited. */
   changed: DateTime;
   /** The date and time that the content was created. */
   created: DateTime;
@@ -569,33 +572,34 @@ export type NodeInterface = {
   id: Scalars['ID']['output'];
   /** Language */
   langcode: Language;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Forfremmet til forside */
+  /** Promoted to front page */
   promote: Scalars['Boolean']['output'];
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Klæbrig */
+  /** Sticky at top of lists */
   sticky: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
   url: Scalars['String']['output'];
 };
 
 /**
- * Sider kan anvendes til en bred vifte af indhold af mere eller mindre blivende
- * karakter. En side kan være simpel og indeholde tekst om fx. låneregler, men
- * kan også være en strukturerende enhed, hvis formål er at udstille andre sider
- * i en sektion med henblik på formidling eller navigation.
+ * Pages can be used for various types of content, either temporary or permanent. A
+ * page can be simple, containing text about, for example, loan rules, or it can
+ * serve as a structural unit designed to display other pages in a section for
+ * communication or navigation.
  */
 export type NodePage = NodeInterface & {
   __typename?: 'NodePage';
-  /** Bibliotek */
+  /** Branch */
   branch?: Maybe<NodeUnion>;
   /**
-   * Hvis du vil gøre denne side til en strukturerende side, skal du gemme siden
-   * først og  <a href="/admin/structure/taxonomy/manage/breadcrumb_structure/add"
-   * target="_blank">tilføje den som en reference i strukturtræet.
+   * TODO: A text about how the structure tree works.<br><br />"If you want to make
+   * this page central, you need to save it first, and then <a
+   * href="/admin/structure/taxonomy/manage/breadcrumb_structure/add"
+   * target="_blank">add it as a reference in the content structure tree</a>
    */
   breadcrumbParent?: Maybe<TermUnion>;
   /**
@@ -605,16 +609,19 @@ export type NodePage = NodeInterface & {
    * content issues and ensuring proper attribution to the original source.
    */
   canonicalUrl?: Maybe<Link>;
-  /** Tidspunktet hvor indholdselementet sidst blev redigeret. */
+  /** The time that the node was last edited. */
   changed: DateTime;
   /** The date and time that the content was created. */
   created: DateTime;
   /**
-   * Som standard vises titel og manchettekst ikke på indholdstypen sider.  Hvis
-   * du vil have dem vist, kan du slå det til her.
+   * By default, titles and subtitles are not displayed on pages. If you wish to
+   * have it displayed, you can enable this setting.
    */
   displayTitles?: Maybe<Scalars['Boolean']['output']>;
-  /** Titlen, der er vist øverst på siden.<br /><br /> <strong>Hvis den er tom, bliver standardsiden brugt i stedet.</strong>. */
+  /**
+   * The title that is shown at the top of the page.<br /><br /><strong>If this is
+   * empty, the standard page title will be used instead.</strong>
+   */
   heroTitle?: Maybe<Scalars['String']['output']>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
@@ -622,26 +629,27 @@ export type NodePage = NodeInterface & {
   langcode: Language;
   /** Paragraphs */
   paragraphs?: Maybe<Array<ParagraphUnion>>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Forfremmet til forside */
+  /** Promoted to front page */
   promote: Scalars['Boolean']['output'];
-  /** Udgivelsesdato */
+  /** Publication date */
   publicationDate: DateTime;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Klæbrig */
+  /** Sticky at top of lists */
   sticky: Scalars['Boolean']['output'];
-  /** Manchet */
+  /** Subtitle */
   subtitle?: Maybe<Scalars['String']['output']>;
   /**
-   * Teaserfelterne bruges til cards som blikfang for indholdet. Hvis der ikke er
-   * valgt et teaserbillede, vil teksten vises i stedet.
+   * The teaser fields are used for the card of display.<br />If no image has been
+   * selected, the text will be shown instead:<br /><br /><img
+   * src="/themes/custom/novel/images/teaser-text-image.jpg" /><br /><br /><hr/>
    */
   teaserImage?: Maybe<MediaUnion>;
-  /** Teasertekst */
+  /** Teaser text */
   teaserText?: Maybe<Scalars['String']['output']>;
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
   url: Scalars['String']['output'];
 };
@@ -652,9 +660,9 @@ export type NodeUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPag
 /** Entity type paragraph. */
 export type ParagraphAccordion = ParagraphInterface & {
   __typename?: 'ParagraphAccordion';
-  /** Accordion beskrivelse */
+  /** Accordion description */
   accordionDescription?: Maybe<Text>;
-  /** Accordion titel */
+  /** Accordion title */
   accordionTitle: Text;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -662,18 +670,18 @@ export type ParagraphAccordion = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Bannerets funktion er at linke til internt indhold, og kan bruges med eller uden baggrundsbillede. */
+/** Banner's purpose is to link internally or externally and can be used with or without a background image. */
 export type ParagraphBanner = ParagraphInterface & {
   __typename?: 'ParagraphBanner';
-  /** Bannerbeskrivelse */
+  /** Banner description */
   bannerDescription?: Maybe<Scalars['String']['output']>;
-  /** Bannerbillede */
+  /** Banner Image */
   bannerImage?: Maybe<MediaUnion>;
-  /** Bannerlink */
+  /** Banner Link */
   bannerLink: Link;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -681,16 +689,19 @@ export type ParagraphBanner = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Understreget titel */
+  /** Underlined title */
   underlinedTitle?: Maybe<Text>;
 };
 
-/** Vis automatisk alt indhold, som refererer til dit valgte brødkrumme element. */
+/** Automatically display all content that is referencing your chosen breadcrumb item. */
 export type ParagraphBreadcrumbChildren = ParagraphInterface & {
   __typename?: 'ParagraphBreadcrumbChildren';
-  /** Vælg en sideforælder i brødkrummestrukturen, hvis sidebørn skal vises. Kun ét niveau af sidebørn kan vises. */
+  /**
+   * Choose a parent in the breadcrumb structure, from which the children will be
+   * displayed. <br><br />Only one level of children will be shown.
+   */
   breadcrumbTarget?: Maybe<TermUnion>;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -698,13 +709,13 @@ export type ParagraphBreadcrumbChildren = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Vis undertekster */
+  /** Show subtitles */
   showSubtitles?: Maybe<Scalars['Boolean']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** En regel til at vælge en matchende kampagne */
+/** A rule for selecting a matching campaign */
 export type ParagraphCampaignRule = ParagraphInterface & {
   __typename?: 'ParagraphCampaignRule';
   /** Facet */
@@ -717,7 +728,7 @@ export type ParagraphCampaignRule = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -726,25 +737,25 @@ export type ParagraphCardGridAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphCardGridAutomatic';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Hvis der ikke vælges noget, vil ALT automatisk blive valgt. */
+  /** If nothing is selected, all will be chosen. */
   filterBranches?: Maybe<Array<NodeUnion>>;
-  /** Filter efter kategorier */
+  /** Filter by categories */
   filterCategories?: Maybe<Array<TermUnion>>;
-  /** Tilstandstype */
+  /** Condition type */
   filterCondType: Scalars['String']['output'];
-  /** Hvis intet er valgt, vil alt blive valgt. */
+  /** If nothing is selected, all will be chosen. */
   filterContentTypes?: Maybe<Array<Scalars['String']['output']>>;
-  /** Filter efter tags */
+  /** Filter by tags */
   filterTags?: Maybe<Array<TermUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Flere links */
+  /** More link */
   moreLink?: Maybe<Link>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -753,27 +764,27 @@ export type ParagraphCardGridManual = ParagraphInterface & {
   __typename?: 'ParagraphCardGridManual';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Indhold */
+  /** Content */
   gridContent?: Maybe<Array<ParagraphCardGridManualGridContentUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Flere links */
+  /** More link */
   moreLink?: Maybe<Link>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Overskrift */
+  /** Title */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** Indhold */
+/** Content */
 export type ParagraphCardGridManualGridContentUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage | NodePage;
 
 /** Entity type paragraph. */
 export type ParagraphContentSlider = ParagraphInterface & {
   __typename?: 'ParagraphContentSlider';
-  /** Indhold */
+  /** Contents */
   contentReferences?: Maybe<Array<ParagraphContentSliderContentReferencesUnion>>;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -781,11 +792,11 @@ export type ParagraphContentSlider = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** forældet */
+  /** deprecated */
   title?: Maybe<Scalars['String']['output']>;
-  /** Titel */
+  /** Title */
   underlinedTitle?: Maybe<Text>;
 };
 
@@ -794,32 +805,32 @@ export type ParagraphContentSliderAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphContentSliderAutomatic';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Hvis der ikke vælges noget, vil ALT automatisk blive valgt. */
+  /** If nothing is selected, all will be chosen. */
   filterBranches?: Maybe<Array<NodeUnion>>;
-  /** Filtrer efter kategori */
+  /** Filter by categories */
   filterCategories?: Maybe<Array<TermUnion>>;
-  /** Tilstandstype */
+  /** Condition type */
   filterCondType: Scalars['String']['output'];
-  /** Hvis intet er valgt, vil alt blive valgt. */
+  /** If nothing is selected, all will be chosen. */
   filterContentTypes?: Maybe<Array<Scalars['String']['output']>>;
-  /** Filtrer efter tags */
+  /** Filter by tags */
   filterTags?: Maybe<Array<TermUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titel (forældet) */
+  /** deprecated */
   title?: Maybe<Scalars['String']['output']>;
-  /** Titel */
+  /** Title */
   underlinedTitle?: Maybe<Text>;
 };
 
-/** Indhold */
+/** Contents */
 export type ParagraphContentSliderContentReferencesUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage | NodePage;
 
-/** En kombination af navn på billetkategori og pris på et arrangement.  */
+/** A combination of ticket category name and price for an event.  */
 export type ParagraphEventTicketCategory = ParagraphInterface & {
   __typename?: 'ParagraphEventTicketCategory';
   /** The time that the Paragraph was created. */
@@ -828,55 +839,55 @@ export type ParagraphEventTicketCategory = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Navn */
+  /** Name */
   ticketCategoryName: Scalars['String']['output'];
 };
 
-/** Link med ikoner. Designet til jpg, jpeg, png, pdf, mp3, mov, mp4, og mpeg filer */
+/** Links with icons. Designed for jpg, jpeg, png, pdf, mp3, mov, mp4, mpeg files */
 export type ParagraphFiles = ParagraphInterface & {
   __typename?: 'ParagraphFiles';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Filer */
+  /** Files */
   files?: Maybe<Array<MediaUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Denne paragraph viser en liste af arrangementer filtreret på kategori, tags og filialer. */
+/** This paragraph displays a generated a list of events, based on specified filters for tags, categories and branches.  */
 export type ParagraphFilteredEventList = ParagraphInterface & {
   __typename?: 'ParagraphFilteredEventList';
-  /** Dette felt bruges ikke længere og vil blive slettet i fremtiden. */
+  /** This field is no longer in use, and will be deleted in the future. */
   amountOfEvents?: Maybe<Scalars['Int']['output']>;
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Hvis der ikke vælges noget, vil ALT automatisk blive valgt. */
+  /** If nothing is selected, all will be chosen. */
   filterBranches?: Maybe<Array<NodeUnion>>;
-  /** Tilføj en kategori, du vil inkludere */
+  /** Add a category you want to include */
   filterCategories?: Maybe<Array<TermUnion>>;
-  /** Tilstandstype */
+  /** Condition type */
   filterCondType: Scalars['String']['output'];
-  /** Tilføj et tag, du vil inkludere */
+  /** Add a tag you want to include */
   filterTags?: Maybe<Array<TermUnion>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
   /**
-   * Vælg antallet af arrangementer, du ønsker at vise. <br /><br />Hvis antallet
-   * vist er mindre end det, du har angivet her, skyldes det sandsynligvis, at der
-   * ikke er nok resultater baseret på dine valgte filtre.
+   * Select the amount of events you want to display. <br /><br />If the amount
+   * displayed is less than what you put here, it is likely because there are not
+   * enough results based on your selected filters.
    */
   maxItemAmount: Scalars['String']['output'];
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -885,13 +896,13 @@ export type ParagraphGoImages = ParagraphInterface & {
   __typename?: 'ParagraphGoImages';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Billeder */
+  /** Images */
   goImages: Array<MediaUnion>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -912,9 +923,9 @@ export type ParagraphGoLink = ParagraphInterface & {
   langcode: Language;
   /** Link */
   link: Link;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Åbn link i et nyt vindue */
+  /** Open link in a new window */
   targetBlank?: Maybe<Scalars['Boolean']['output']>;
 };
 
@@ -923,11 +934,11 @@ export type ParagraphGoLinkbox = ParagraphInterface & {
   __typename?: 'ParagraphGoLinkbox';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Farve */
+  /** Color */
   goColor?: Maybe<Scalars['String']['output']>;
-  /** Beskrivelse */
+  /** Description */
   goDescription: Scalars['String']['output'];
-  /** Billede */
+  /** Image */
   goImage?: Maybe<MediaUnion>;
   /** Link */
   goLinkParagraph: ParagraphUnion;
@@ -935,9 +946,9 @@ export type ParagraphGoLinkbox = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
 };
 
@@ -945,11 +956,11 @@ export type ParagraphGoLinkbox = ParagraphInterface & {
 export type ParagraphGoMaterialSliderAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphGoMaterialSliderAutomatic';
   /**
-   * Dette felt er til at indsætte en CQL-søgestreng baseret på en søgning. <br
-   * /><br />Vær opmærksom på, at det er nødvendigt at kopiere den nøjagtige
-   * CQL-streng, inklusive citationstegn. dvs.: ( 'harry potter')<br /><br />En
-   * gyldig CQL-søgestreng kan genereres ved at udføre en forespørgsel gennem
-   * den avancerede søgning og kopiere CQL-strengen derfra.
+   * This field is for inserting a CQL string based on a search. <br /><br />Please
+   * be aware, that it is necessary to copy the exact CQL string, including the
+   * quotations. i.e: ( 'harry potter')<br /><br />A valid CQL search string can be
+   * generated, by performing a query through the advanced search, and copying the
+   * CQL string from there.
    */
   cqlSearch: CqlSearch;
   /** The time that the Paragraph was created. */
@@ -958,11 +969,11 @@ export type ParagraphGoMaterialSliderAutomatic = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Antal materialer */
+  /** Amount of materials */
   sliderAmountOfMaterials: Scalars['Int']['output'];
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
 };
 
@@ -984,9 +995,9 @@ export type ParagraphGoMaterialSliderManual = ParagraphInterface & {
    * if it is available.<br />Example work ID: work-of:870970-basis:136336282
    */
   materialSliderWorkIds: Array<WorkId>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title: Scalars['String']['output'];
 };
 
@@ -1005,11 +1016,11 @@ export type ParagraphGoTextBody = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Angiv URL-en for den video, der skal vises */
+/** Enter the URL for the video you want to include. */
 export type ParagraphGoVideo = ParagraphInterface & {
   __typename?: 'ParagraphGoVideo';
   /** The time that the Paragraph was created. */
@@ -1020,45 +1031,45 @@ export type ParagraphGoVideo = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titl */
+  /** Title */
   title: Scalars['String']['output'];
 };
 
 /**
- * Denne paragraph bruges til at vise en VideoTool-video og vise et sæt relaterede
- * bøger. De relaterede bøger vælges automatisk baseret på en CQL-søgestreng.
+ * This paragraph is used for displaying a VideoTool video and display a set of
+ * related books. The related books is automatically chosen based on a CQL search
  */
 export type ParagraphGoVideoBundleAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphGoVideoBundleAutomatic';
   /**
-   * Dette felt er til at indsætte en CQL-søgestreng baseret på en søgning. <br
-   * /><br />Vær opmærksom på, at det er nødvendigt at kopiere den nøjagtige
-   * CQL-streng, inklusive citationstegn. dvs.: ( 'harry potter')<br /><br />En
-   * gyldig CQL-søgestreng kan genereres ved at udføre en forespørgsel gennem
-   * den avancerede søgning og kopiere CQL-strengen derfra.
+   * This field is for inserting a CQL string based on a search. <br /><br />Please
+   * be aware, that it is necessary to copy the exact CQL string, including the
+   * quotations. i.e: ( 'harry potter')<br /><br />A valid CQL search string can be
+   * generated, by performing a query through the advanced search, and copying the
+   * CQL string from there.
    */
   cqlSearch: CqlSearch;
   /** The time that the Paragraph was created. */
   created: DateTime;
   /** Embed video */
   embedVideo: MediaUnion;
-  /** Titel */
+  /** Title */
   goVideoTitle: Scalars['String']['output'];
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Antal af ​​relaterede materialer, der skal vises. */
+  /** The amount of related materials that should be shown. */
   videoAmountOfMaterials: Scalars['Int']['output'];
 };
 
 /**
- * Denne paragraph bruges til at vise en VideoTool-video og vise et sæt relaterede
- * eller anbefalede materialer. Materialerne kan vælges manuelt.
+ * This paragraph is used for displaying a VideoTool video and display a set of
+ * related or recommended materials. The materials can be selected manually.
  */
 export type ParagraphGoVideoBundleManual = ParagraphInterface & {
   __typename?: 'ParagraphGoVideoBundleManual';
@@ -1066,47 +1077,46 @@ export type ParagraphGoVideoBundleManual = ParagraphInterface & {
   created: DateTime;
   /** Embed video */
   embedVideo: MediaUnion;
-  /** Titel */
+  /** Title */
   goVideoTitle: Scalars['String']['output'];
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
   /**
-   * Her kan du vælge, hvilke materialer der skal vises. Hvis du har brug for at
-   * linke til en bestemt type, skal du vælge den fra rullemenuen, og systemet vil
-   * vise det, hvis det er tilgængeligt.<br />Example work ID:
-   * work-of:870970-basis:136336282
+   * Here you can choose which materials to display. If you need to link to a
+   * specific type, select it from the dropdown and the system will display that,
+   * if it is available.<br />Example work ID: work-of:870970-basis:136336282
    */
   videoBundleWorkIds?: Maybe<Array<WorkId>>;
 };
 
-/** En Hero til placering øverst på forsiden med et billede, informativ tekst, kategori og et link til fremhævet indhold. */
+/** A hero section with an image, informative text, category, and a "call to action" link. */
 export type ParagraphHero = ParagraphInterface & {
   __typename?: 'ParagraphHero';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Hero kategori */
+  /** Hero categories */
   heroCategories?: Maybe<TermUnion>;
-  /** Hero indholdstype */
+  /** Hero content type */
   heroContentType?: Maybe<Scalars['String']['output']>;
-  /** Hero dato */
+  /** Hero date */
   heroDate?: Maybe<DateTime>;
-  /** Hero beskrivelse */
+  /** Hero description */
   heroDescription?: Maybe<Text>;
-  /** Hero billede */
+  /** Hero image */
   heroImage?: Maybe<MediaUnion>;
   /** Hero link */
   heroLink?: Maybe<Link>;
-  /** Overskrift */
+  /** Hero title */
   heroTitle: Scalars['String']['output'];
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -1118,11 +1128,11 @@ export type ParagraphInterface = {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Giver besøgende på sitet mulighed for at vælge foretrukket sprog */
+/** Enables website visitors to choose their preferred language. */
 export type ParagraphLanguageSelector = ParagraphInterface & {
   __typename?: 'ParagraphLanguageSelector';
   /** The time that the Paragraph was created. */
@@ -1131,13 +1141,13 @@ export type ParagraphLanguageSelector = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Sprogikon */
+  /** Language icon */
   languageIcon: Image;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Links med ikoner. Designet til interne/eksterne links og links til søgeresultater ␣. */
+/** Links with icons. Designed for internal/external links and links to search results.  */
 export type ParagraphLinks = ParagraphInterface & {
   __typename?: 'ParagraphLinks';
   /** The time that the Paragraph was created. */
@@ -1148,24 +1158,24 @@ export type ParagraphLinks = ParagraphInterface & {
   langcode: Language;
   /** Link */
   link: Array<Link>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Dette afsnit vil vise en liste over arrangementer, der er manuelt valgt. */
+/** This paragraph will show a list of events that are manually selected. */
 export type ParagraphManualEventList = ParagraphInterface & {
   __typename?: 'ParagraphManualEventList';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Arrangementer */
+  /** Events */
   events?: Maybe<Array<UnsupportedType>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Titel */
+  /** Title */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -1176,18 +1186,18 @@ export type ParagraphManualEventList = ParagraphInterface & {
 export type ParagraphMaterialGridAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphMaterialGridAutomatic';
   /**
-   * Bestemmer mængden af materialer, der vil blive vist, baseret på
-   * CQL-strengen. <br /><br />Obs: Hvis for eksempel en CQL-streng har 11
-   * resultater, og en redaktør vælger 12. Listen vil vise 8 i stedet for 11, da
-   * gitteret skal kunne øges med 4.
+   * Determines the amount of materials that will be shown, based on the CQL
+   * string. <br /><br />Obs: If for example a CQL string has 11 results, and an
+   * editor chooses 12. The list will display 8 instead of 11, since the grid
+   * should be able to increment by 4.
    */
   amountOfMaterials: Scalars['Int']['output'];
   /**
-   * Dette felt er til indsættelse af en CQL-streng baseret på en søgning. <br
-   * /><br />Vær opmærksom på, at det er nødvendigt at kopiere den nøjagtige
-   * CQL-streng, inklusive anførselstegnene. dvs: ('harry potter')<br /><br />En
-   * gyldig CQL-søgestreng kan genereres ved at udføre en forespørgsel gennem
-   * den avancerede søgning og kopiere CQL-strengen derfra.
+   * This field is for inserting a CQL string based on a search. <br /><br />Please
+   * be aware, that it is necessary to copy the exact CQL string, including the
+   * quotations. i.e: ( 'harry potter')<br /><br />A valid CQL search string can be
+   * generated, by performing a query through the advanced search, and copying the
+   * CQL string from there.
    */
   cqlSearch: CqlSearch;
   /** The time that the Paragraph was created. */
@@ -1196,14 +1206,11 @@ export type ParagraphMaterialGridAutomatic = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /**
-   * Dette er en valgfri beskrivelsestekst, der kan ledsage materiale grid'et. Lad
-   * feltet være tomt, hvis du ikke ønsker en beskrivelse.
-   */
+  /** This is the optional description for the material grid. <br />Leave blank if you do not want a description. */
   materialGridDescription?: Maybe<Scalars['String']['output']>;
-  /** Titel på materialekomponenten. Efterlad dette felt blankt, hvis du ikke vil give den en overskrift. */
+  /** The title for the material grid. Leave this blank if you do not want a title.  */
   materialGridTitle?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -1226,18 +1233,19 @@ export type ParagraphMaterialGridLinkAutomatic = ParagraphInterface & {
   /** This is the optional description for the material grid. <br />Leave blank if you do not want a description. */
   materialGridDescription?: Maybe<Scalars['String']['output']>;
   /**
-   * Tilføj et link her, som er genereret ved hjælp af avanceret søgning -> CQL
-   * /><br />Bemærk at en søgning, der er foretaget vha feltsøgning under
-   * avanceret søgning, ikke virker. Der SKAL benyttes CQL.
+   * This field is for inserting a link string based on a search, e.g.:
+   * /><br />Please be aware that it is necessary to copy the exact link string.<br
+   * /><br />A valid link search string can be generated, by performing a query
+   * through the advanced search and copying the link string from there.
    */
   materialGridLink: Scalars['String']['output'];
-  /** Der vises ikke en titel, hvis denne er tom. */
+  /** The title for the material grid. Leave this blank if you do not want a title.  */
   materialGridTitle?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** En komponent som viser en liste af manuelt udvalgte værker. */
+/** A grid displaying a list of recommended materials selected manually. */
 export type ParagraphMaterialGridManual = ParagraphInterface & {
   __typename?: 'ParagraphMaterialGridManual';
   /** The time that the Paragraph was created. */
@@ -1246,23 +1254,20 @@ export type ParagraphMaterialGridManual = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /**
-   * Dette er en valgfri beskrivelsestekst, der kan ledsage materiale grid'et. Lad
-   * feltet være tomt, hvis du ikke ønsker en beskrivelse.
-   */
+  /** This is the optional description for the material grid. <br />Leave blank if you do not want a description. */
   materialGridDescription?: Maybe<Scalars['String']['output']>;
-  /** Titel på materialekomponenten. Efterlad dette felt blankt, hvis du ikke vil give den en overskrift. */
+  /** The title for the material grid. Leave this blank if you do not want a title.  */
   materialGridTitle?: Maybe<Scalars['String']['output']>;
   /**
-   * Gitteret vil kun vise materialer i intervaller af 4. <br /><br />Eksempel
-   * arbejds ID: work-of:870970-basis:136336282.<br /><br />Hvis du skal linke til
-   * en specifik type, vælg den fra dropdown-menuen og systemet vil vise den, hvis
-   * den er tilgængelig.
+   * The grid will only display materials in internvals of 4. <br /><br />Example
+   * work ID: work-of:870970-basis:136336282.<br /><br />If you need to link to a
+   * specific type, select it from the dropdown and the system will display that,
+   * if it is available.
    */
   materialGridWorkIds?: Maybe<Array<WorkId>>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Dette felt vil blive slettet i fremtiden. Brug venligst det andet VærkID felt. */
+  /** This field will be deleted in the future. Please use another work id field. */
   workId?: Maybe<Array<WorkId>>;
 };
 
@@ -1275,16 +1280,16 @@ export type ParagraphMedias = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Billeder */
+  /** Medias */
   medias: Array<MediaUnion>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
 /** Entity type paragraph. */
 export type ParagraphNavGridManual = ParagraphInterface & {
   __typename?: 'ParagraphNavGridManual';
-  /** Indhold */
+  /** Contents */
   contentReferences?: Maybe<Array<ParagraphNavGridManualContentReferencesUnion>>;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -1292,13 +1297,13 @@ export type ParagraphNavGridManual = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Vis manchettekster */
+  /** Show subtitles */
   showSubtitles?: Maybe<Scalars['Boolean']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Indhold */
+/** Contents */
 export type ParagraphNavGridManualContentReferencesUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage | NodePage;
 
 /** Entity type paragraph. */
@@ -1310,7 +1315,7 @@ export type ParagraphNavSpotsManual = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -1327,11 +1332,11 @@ export type ParagraphOpeningHours = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Denne paragraph bruges til at anbefale et enkelt materiale. */
+/** This paragraph is used to recommend a material.  */
 export type ParagraphRecommendation = ParagraphInterface & {
   __typename?: 'ParagraphRecommendation';
   /** The time that the Paragraph was created. */
@@ -1339,36 +1344,36 @@ export type ParagraphRecommendation = ParagraphInterface & {
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /**
-   * Dette bestemmer om, et billede skal positioneres til venstre eller højre. <br
-   * />Hvis den ikke er slået til (standardadfærd), placeres billedet til
-   * venstre, hvis den er slået til, placeres billedet til højre.␣
+   * This determines whether the image should be positioned to the left or right.
+   * <br />If left untoggled (default behaviour) the image is positioned to the
+   * left, if toggled on, the image will be positioned to the right.
    */
   imagePositionRight?: Maybe<Scalars['Boolean']['output']>;
   /** The paragraphs entity language code. */
   langcode: Language;
   /**
-   * Dette er beskrivelsen af det anbefalede materiale. Hvis du tilføjer en
-   * beskrivelsestekst, vil titlen på materialet ikke blive autoudfyldt.
+   * This is the description for a recommendation. <br /><br />If you add a
+   * description, the title of the the material will not be automatically
    */
   recommendationDescription?: Maybe<Scalars['String']['output']>;
   /**
-   * Titlen på det anbefalede materiale. Hvis du tilføjer en titel, vil
-   * beskrivelsesteksten af materialet ikke blive autoudfyldt.
+   * The title of the recommended material.<br /><br />If you add a title, the
+   * description for the material will not be automatically generated.
    */
   recommendationTitle?: Maybe<Text>;
   /**
-   * Dette er det arbejds-ID, der bruges til at hente materialeoplysningerne.
-   * Eksempel: work-of:870970-basis:136336282.<br />I øjeblikket hentes dette ved
-   * at udføre en søgning efter et materiale manuelt og kopiere denne værdi fra
-   * URL'en.<br />Hvis du har brug for at linke til en bestemt type, skal du vælge
-   * den fra rullemenuen, og systemet vil vise den, hvis den er tilgængelig.
+   * This is the work ID used to retrieve the material information. Example:
+   * work-of:870970-basis:136336282.<br />Currently this is retrieved by performing
+   * a search for a material manually, and copying this value from the URL.<br />If
+   * you need to link to a specific type, select it from the dropdown and the
+   * system will display that, if it is available.
    */
   recommendationWorkId?: Maybe<WorkId>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Denne paragraph viser links uden ikoner. */
+/** This is paragraph that will display links without icons.  */
 export type ParagraphSimpleLinks = ParagraphInterface & {
   __typename?: 'ParagraphSimpleLinks';
   /** The time that the Paragraph was created. */
@@ -1379,14 +1384,14 @@ export type ParagraphSimpleLinks = ParagraphInterface & {
   langcode: Language;
   /** Link */
   link: Array<Link>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** En basal, formateret brødtekst */
+/** A basic, formatted body of text. */
 export type ParagraphTextBody = ParagraphInterface & {
   __typename?: 'ParagraphTextBody';
-  /** Brødtekst */
+  /** Body */
   body: Text;
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -1394,42 +1399,42 @@ export type ParagraphTextBody = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
 /** Entity type paragraph. */
 export type ParagraphUnion = ParagraphAccordion | ParagraphBanner | ParagraphBreadcrumbChildren | ParagraphCampaignRule | ParagraphCardGridAutomatic | ParagraphCardGridManual | ParagraphContentSlider | ParagraphContentSliderAutomatic | ParagraphEventTicketCategory | ParagraphFiles | ParagraphFilteredEventList | ParagraphGoImages | ParagraphGoLink | ParagraphGoLinkbox | ParagraphGoMaterialSliderAutomatic | ParagraphGoMaterialSliderManual | ParagraphGoTextBody | ParagraphGoVideo | ParagraphGoVideoBundleAutomatic | ParagraphGoVideoBundleManual | ParagraphHero | ParagraphLanguageSelector | ParagraphLinks | ParagraphManualEventList | ParagraphMaterialGridAutomatic | ParagraphMaterialGridLinkAutomatic | ParagraphMaterialGridManual | ParagraphMedias | ParagraphNavGridManual | ParagraphNavSpotsManual | ParagraphOpeningHours | ParagraphRecommendation | ParagraphSimpleLinks | ParagraphTextBody | ParagraphUserRegistrationItem | ParagraphUserRegistrationLinklist | ParagraphUserRegistrationSection | ParagraphVideo | ParagraphWebform;
 
-/** "Brugerregistreringselement" anvendes til at vise relevant information om brugerregistreringsprocessen. */
+/** The "User registration item" paragraph type is used to display relevant information about the user registration process. */
 export type ParagraphUserRegistrationItem = ParagraphInterface & {
   __typename?: 'ParagraphUserRegistrationItem';
-  /** Anker */
+  /** Anchor */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Brødtekst */
+  /** Body */
   body: Text;
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Aktivér denne indstilling for at få vist en knap øverst på siden, så det er nemmere at navigere. */
+  /** Enable this option to display a button at the top of the page for easier navigation. */
   displayInNavigation?: Maybe<Scalars['Boolean']['output']>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Angiv hvordan et linket dokument skal åbne når en bruger klikker på linket. */
+  /** Specify how a linked document should be opened when clicked by a user. */
   linkTarget: Scalars['String']['output'];
-  /** Hvis titelfeltet på navigationsknappen ikke udfyldes, vil den automatisk få titlen på denne Paragraph. */
+  /** If the navigation button title is left blank, it will automatically default to the paragraph title. */
   navigationTitle?: Maybe<Scalars['String']['output']>;
-  /** Registreringslink */
+  /** Registration Link */
   registrationLink?: Maybe<Link>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
 /**
- * Denne paragraph bestemmer placeringen af genveje til
- * "Brugeregistreingsparagraphs". Paragraphen tillader redaktører at specificere,
- * om disse genveje skal vises.
+ * This paragraph determines the placement of shortcuts to individual User
+ * Registration Section paragraphs. It allows administrators to specify where these
+ * shortcuts should appear.
  */
 export type ParagraphUserRegistrationLinklist = ParagraphInterface & {
   __typename?: 'ParagraphUserRegistrationLinklist';
@@ -1439,11 +1444,11 @@ export type ParagraphUserRegistrationLinklist = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** "Brugerregistreringsparagraph" bruges til at vise "Brugerregistreringselementer". */
+/** The "User registration section" paragraph type is used to display "User registration item" paragraphs. */
 export type ParagraphUserRegistrationSection = ParagraphInterface & {
   __typename?: 'ParagraphUserRegistrationSection';
   /** The time that the Paragraph was created. */
@@ -1452,26 +1457,26 @@ export type ParagraphUserRegistrationSection = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Indtast URL'en til den video, du vil indlejre. */
+/** Enter the URL for the video you want to include. */
 export type ParagraphVideo = ParagraphInterface & {
   __typename?: 'ParagraphVideo';
   /** The time that the Paragraph was created. */
   created: DateTime;
-  /** Indlejr video */
+  /** Embed video */
   embedVideo: MediaUnion;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
-/** Paragraph brugt til indlejring af en webformular. */
+/** Paragraph used for embedding a webform. */
 export type ParagraphWebform = ParagraphInterface & {
   __typename?: 'ParagraphWebform';
   /** The time that the Paragraph was created. */
@@ -1480,7 +1485,7 @@ export type ParagraphWebform = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
 };
 
@@ -1608,9 +1613,9 @@ export type SchemaInformation = {
 
 /** Sort direction. */
 export type SortDirection =
-  /** Stigende */
+  /** Ascending */
   | 'ASC'
-  /** Faldende */
+  /** Descending */
   | 'DESC';
 
 /** The schema's entry-point for subscriptions. */
@@ -1623,145 +1628,145 @@ export type Subscription = {
 /** Entity type taxonomy_term. */
 export type TermBreadcrumbStructure = TermInterface & {
   __typename?: 'TermBreadcrumbStructure';
-  /** Datoen hvor termen senest blev redigeret. */
+  /** The time that the term was last edited. */
   changed: DateTime;
-  /** Titlen, der vises over listen af refereret indhold. Vil ikke blive vist, hvis der ikke vises nogen børn. */
+  /** The title that is shown above the list of referenced content. Will not be shown, if there are no children displayed. */
   childrenTitle?: Maybe<Scalars['String']['output']>;
-  /** Indhold der linkes til */
+  /** Content */
   content: NodeUnion;
-  /** Beskrivelse */
+  /** Description */
   description: Text;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Term sprogkode. */
+  /** The term language code. */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Denne terms overordnede termer. */
+  /** The parents of this term. */
   parent?: Maybe<TermUnion>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Vis en automatisk liste med indhold, som refererer til dette brødkrumme element, på denne side. */
+  /** Should a list of contents that reference this breadcrumb, be shown automatically on this page? */
   showChildren?: Maybe<Scalars['Boolean']['output']>;
-  /** Sæt hak her, hvis børnebrødkrummen skal udfoldes med eventuelle undertitel */
+  /** If this is checked, the children teasers will be expanded with possible subtitle descriptions. */
   showChildrenSubtitles?: Maybe<Scalars['Boolean']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Vægten af denne term i forhold til andre termer. */
+  /** The weight of this term in relation to other terms. */
   weight: Scalars['Int']['output'];
 };
 
 /** Entity type taxonomy_term. */
 export type TermCategories = TermInterface & {
   __typename?: 'TermCategories';
-  /** Datoen hvor termen senest blev redigeret. */
+  /** The time that the term was last edited. */
   changed: DateTime;
-  /** Beskrivelse */
+  /** Description */
   description: Text;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Term sprogkode. */
+  /** The term language code. */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Denne terms overordnede termer. */
+  /** The parents of this term. */
   parent?: Maybe<TermUnion>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Vægten af denne term i forhold til andre termer. */
+  /** The weight of this term in relation to other terms. */
   weight: Scalars['Int']['output'];
 };
 
 /** Entity type taxonomy_term. */
 export type TermInterface = {
-  /** Datoen hvor termen senest blev redigeret. */
+  /** The time that the term was last edited. */
   changed: DateTime;
-  /** Beskrivelse */
+  /** Description */
   description: Text;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Term sprogkode. */
+  /** The term language code. */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Denne terms overordnede termer. */
+  /** The parents of this term. */
   parent?: Maybe<TermUnion>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Vægten af denne term i forhold til andre termer. */
+  /** The weight of this term in relation to other terms. */
   weight: Scalars['Int']['output'];
 };
 
-/** This is for adding types of opening hours, e.g. "open" or "Telephone time" */
+/** Kategorier af åbningstider, f.eks. "Åbent" eller "Telefontid" */
 export type TermOpeningHoursCategories = TermInterface & {
   __typename?: 'TermOpeningHoursCategories';
-  /** Datoen hvor termen senest blev redigeret. */
+  /** The time that the term was last edited. */
   changed: DateTime;
-  /** Beskrivelse */
+  /** Description */
   description: Text;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Term sprogkode. */
+  /** The term language code. */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Denne terms overordnede termer. */
+  /** The parents of this term. */
   parent?: Maybe<TermUnion>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Vægten af denne term i forhold til andre termer. */
+  /** The weight of this term in relation to other terms. */
   weight: Scalars['Int']['output'];
 };
 
 /** Screens to display content on */
 export type TermScreenName = TermInterface & {
   __typename?: 'TermScreenName';
-  /** Datoen hvor termen senest blev redigeret. */
+  /** The time that the term was last edited. */
   changed: DateTime;
-  /** Beskrivelse */
+  /** Description */
   description: Text;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Term sprogkode. */
+  /** The term language code. */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Denne terms overordnede termer. */
+  /** The parents of this term. */
   parent?: Maybe<TermUnion>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Vægten af denne term i forhold til andre termer. */
+  /** The weight of this term in relation to other terms. */
   weight: Scalars['Int']['output'];
 };
 
 /** Entity type taxonomy_term. */
 export type TermTags = TermInterface & {
   __typename?: 'TermTags';
-  /** Datoen hvor termen senest blev redigeret. */
+  /** The time that the term was last edited. */
   changed: DateTime;
-  /** Beskrivelse */
+  /** Description */
   description: Text;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Term sprogkode. */
+  /** The term language code. */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Denne terms overordnede termer. */
+  /** The parents of this term. */
   parent?: Maybe<TermUnion>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Vægten af denne term i forhold til andre termer. */
+  /** The weight of this term in relation to other terms. */
   weight: Scalars['Int']['output'];
 };
 
@@ -1771,25 +1776,25 @@ export type TermUnion = TermBreadcrumbStructure | TermCategories | TermOpeningHo
 /** List of email categories used for sending webform submissions. Each category is associated with an email address. */
 export type TermWebformEmailCategories = TermInterface & {
   __typename?: 'TermWebformEmailCategories';
-  /** Datoen hvor termen senest blev redigeret. */
+  /** The time that the term was last edited. */
   changed: DateTime;
-  /** Beskrivelse */
+  /** Description */
   description: Text;
-  /** Tilføj den e-mail, som henvendelser i denne kategori skal sendes til. */
+  /** Add which email to send form submissions of this category to. */
   email: Scalars['Email']['output'];
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
-  /** Term sprogkode. */
+  /** The term language code. */
   langcode: Language;
-  /** Navn */
+  /** Name */
   name: Scalars['String']['output'];
-  /** Denne terms overordnede termer. */
+  /** The parents of this term. */
   parent?: Maybe<TermUnion>;
-  /** Alternativ URL */
+  /** URL alias */
   path?: Maybe<Scalars['String']['output']>;
-  /** Publiceret */
+  /** Published */
   status: Scalars['Boolean']['output'];
-  /** Vægten af denne term i forhold til andre termer. */
+  /** The weight of this term in relation to other terms. */
   weight: Scalars['Int']['output'];
 };
 
@@ -1828,13 +1833,18 @@ export type Translation = {
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** List of DPL-Go Unilogin configuration. */
-export type UniloginConfiguration = {
-  __typename?: 'UniloginConfiguration';
-  unilogin_api_client_id?: Maybe<Scalars['String']['output']>;
-  unilogin_api_client_secret?: Maybe<Scalars['String']['output']>;
-  unilogin_api_url?: Maybe<Scalars['String']['output']>;
-  unilogin_api_wellknown_url?: Maybe<Scalars['String']['output']>;
+export type UniloginConfigurationPrivate = {
+  __typename?: 'UniloginConfigurationPrivate';
+  clientId?: Maybe<Scalars['String']['output']>;
+  clientSecret?: Maybe<Scalars['String']['output']>;
+  pubHubRetailerKeyCode?: Maybe<Scalars['String']['output']>;
+  webServicePassword?: Maybe<Scalars['String']['output']>;
+  webServiceUsername?: Maybe<Scalars['String']['output']>;
+};
+
+export type UniloginConfigurationPublic = {
+  __typename?: 'UniloginConfigurationPublic';
+  municipalityId?: Maybe<Scalars['String']['output']>;
 };
 
 /**
@@ -1849,7 +1859,7 @@ export type UnsupportedType = {
 
 /** Views represent collections of curated data from the CMS. */
 export type View = {
-  /** Viewets beskrivelse. */
+  /** The description of the view. */
   description?: Maybe<Scalars['String']['output']>;
   /** The machine name of the display. */
   display: Scalars['String']['output'];
@@ -1923,10 +1933,10 @@ export type ViewReference = {
 /** All available view result types. */
 export type ViewResultUnion = GoCategoriesResult;
 
-/** Et WorkID-felt. */
+/** A WorkID field. */
 export type WorkId = {
   __typename?: 'WorkId';
-  /** Materialetype (fx bog, film, lydbog) */
+  /** The material type (e.g., bog, e-bog). */
   material_type?: Maybe<Scalars['String']['output']>;
   /** The WorkID value */
   work_id?: Maybe<Scalars['String']['output']>;
@@ -1982,12 +1992,12 @@ export type GetCategoryPageByPathQuery = { go: { cacheTags: string[] } } & { __t
 export type GetDplCmsPrivateConfigurationQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetDplCmsPrivateConfigurationQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', private?: { __typename?: 'GoConfigurationPrivate', unilogin?: { __typename?: 'UniloginConfiguration', unilogin_api_client_id?: string | null, unilogin_api_client_secret?: string | null, unilogin_api_url?: string | null, unilogin_api_wellknown_url?: string | null } | null } | null } | null };
+export type GetDplCmsPrivateConfigurationQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', private?: { __typename?: 'GoConfigurationPrivate', unilogin?: { __typename?: 'UniloginConfigurationPrivate', clientSecret?: string | null, pubHubRetailerKeyCode?: string | null, webServicePassword?: string | null, webServiceUsername?: string | null } | null } | null } | null };
 
 export type GetDplCmsPublicConfigurationQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetDplCmsPublicConfigurationQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', public?: { __typename?: 'GoConfigurationPublic', loginUrls?: { __typename?: 'GoLoginUrls', adgangsplatformen?: string | null } | null, logoutUrls?: { __typename?: 'GoLogoutUrls', adgangsplatformen?: string | null } | null, libraryInfo?: { __typename?: 'GoLibraryInfo', name?: string | null } | null } | null } | null };
+export type GetDplCmsPublicConfigurationQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', public?: { __typename?: 'GoConfigurationPublic', libraryInfo?: { __typename?: 'GoLibraryInfo', name?: string | null } | null, loginUrls?: { __typename?: 'GoLoginUrls', adgangsplatformen?: string | null } | null, logoutUrls?: { __typename?: 'GoLogoutUrls', adgangsplatformen?: string | null } | null, unilogin?: { __typename?: 'UniloginConfigurationPublic', municipalityId?: string | null } | null } | null } | null };
 
 export type GetPageByPathQueryVariables = Exact<{
   path: Scalars['String']['input'];
@@ -2434,10 +2444,10 @@ export const GetDplCmsPrivateConfigurationDocument = `
   goConfiguration {
     private {
       unilogin {
-        unilogin_api_client_id
-        unilogin_api_client_secret
-        unilogin_api_url
-        unilogin_api_wellknown_url
+        clientSecret
+        pubHubRetailerKeyCode
+        webServicePassword
+        webServiceUsername
       }
     }
   }
@@ -2487,14 +2497,17 @@ export const GetDplCmsPublicConfigurationDocument = `
     query getDplCmsPublicConfiguration {
   goConfiguration {
     public {
+      libraryInfo {
+        name
+      }
       loginUrls {
         adgangsplatformen
       }
       logoutUrls {
         adgangsplatformen
       }
-      libraryInfo {
-        name
+      unilogin {
+        municipalityId
       }
     }
   }

--- a/lib/graphql/queries/configuration.dpl-cms.graphql
+++ b/lib/graphql/queries/configuration.dpl-cms.graphql
@@ -2,10 +2,10 @@ query getDplCmsPrivateConfiguration {
   goConfiguration {
     private {
       unilogin {
-        unilogin_api_client_id
-        unilogin_api_client_secret
-        unilogin_api_url
-        unilogin_api_wellknown_url
+        clientSecret
+        pubHubRetailerKeyCode
+        webServicePassword
+        webServiceUsername
       }
     }
   }
@@ -14,14 +14,17 @@ query getDplCmsPrivateConfiguration {
 query getDplCmsPublicConfiguration {
   goConfiguration {
     public {
+      libraryInfo {
+        name
+      }
       loginUrls {
         adgangsplatformen
       }
       logoutUrls {
         adgangsplatformen
       }
-      libraryInfo {
-        name
+      unilogin {
+        municipalityId
       }
     }
   }

--- a/lib/helpers/publizon.ts
+++ b/lib/helpers/publizon.ts
@@ -1,13 +1,17 @@
 import { md5 } from "js-md5"
 
+import { getDplCmsPrivateConfig } from "../config/dpl-cms/dplCmsConfig"
 import { getServerEnv } from "../config/env"
 
-export const getPublizonServiceParameters = () => {
+export const getPublizonServiceParameters = async () => {
+  const {
+    unilogin: { pubHubRetailerKeyCode },
+  } = await getDplCmsPrivateConfig()
   return {
     clientid: getServerEnv("UNLILOGIN_PUBHUB_CLIENT_ID") ?? "",
     retailerid: getServerEnv("UNLILOGIN_PUBHUB_RETAILER_ID") ?? "",
     // The  Publizon services expect the retailerkeycode to be an MD5 hash
     // of the actual key code.
-    retailerkeycode: md5(getServerEnv("UNLILOGIN_PUBHUB_RETAILER_KEY_CODE") ?? ""),
+    retailerkeycode: md5(pubHubRetailerKeyCode ?? ""),
   }
 }

--- a/lib/helpers/unilogin.ts
+++ b/lib/helpers/unilogin.ts
@@ -1,16 +1,21 @@
-import { getServerEnv } from "../config/env"
+import { getDplCmsPrivateConfig, getDplCmsPublicConfig } from "../config/dpl-cms/dplCmsConfig"
 
-export const getUniloginWsCredentials = () => {
-  const username = getServerEnv("UNLILOGIN_SERVICES_WS_USER")
-  const password = getServerEnv("UNLILOGIN_SERVICES_WS_PASSWORD")
-
+export const getUniloginWsCredentials = async () => {
+  const {
+    unilogin: { webServiceUsername: username, webServicePassword: password },
+  } = await getDplCmsPrivateConfig()
   return {
     username,
     password,
   }
 }
 
-export const getLibraryMunicipalityId = () => getServerEnv("UNILOGIN_MUNICIPALITY_ID")
+export const getLibraryMunicipalityId = async () => {
+  const {
+    unilogin: { municipalityId },
+  } = await getDplCmsPublicConfig()
+  return municipalityId
+}
 
 export const getInstitutionIds = (text: string) =>
   text.replace(/\[([^\]]*)\]/g, "$1").split(",") ?? []

--- a/lib/session/oauth/uniloginClient.ts
+++ b/lib/session/oauth/uniloginClient.ts
@@ -1,15 +1,18 @@
 import * as client from "openid-client"
 
-import { getDplCmsPrivateUniloginConfig } from "@/lib/config/dpl-cms/dplCmsConfig"
-import { getEnv } from "@/lib/config/env"
+import { getDplCmsPrivateConfig } from "@/lib/config/dpl-cms/dplCmsConfig"
+import { getEnv, getServerEnv } from "@/lib/config/env"
 
 export const uniloginClientSettings = {
   post_login_route: `${getEnv("APP_URL")}/user/profile`,
 }
 
 export async function getUniloginClientConfig() {
-  const { wellknownUrl, clientId, clientSecret } = await getDplCmsPrivateUniloginConfig()
-
+  const {
+    unilogin: { clientSecret },
+  } = await getDplCmsPrivateConfig()
+  const clientId = getServerEnv("UNILOGIN_CLIENT_ID")
+  const wellknownUrl = getServerEnv("UNILOGIN_WELLKNOWN_URL")
   let isMissingConfiguration = false
   // We need all of these to be able to continue.
   // TODO: Consider if we should throw an error instead of just logging.


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Since we need non-generated secrets to come from the cms we move them to the go configuration query.
Also we need to make sure that values are overidable by the use of env variables for testing and development purposes.

