### PR TITLE
Adjust the usage of the suspense wrapper to prevent layout shifts and ensure that certain components do not wait for irrelevant requests from ⁠dpl-cms before rendering

### DIFF
--- a/app/(pages-with-category-slider)/layout.tsx
+++ b/app/(pages-with-category-slider)/layout.tsx
@@ -4,20 +4,11 @@ import CategorySlider, { TNodeGoCategory } from "@/components/shared/categorySli
 import loadCategories from "@/components/shared/categorySlider/loadCategories"
 import "@/styles/globals.css"
 
-async function CategorySliderLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode
-}>) {
+async function CategorySliderLayout() {
   const data = await loadCategories()
   const categories = data?.goCategories?.results as TNodeGoCategory[] | undefined
 
-  return (
-    <div className="min-h-screen-minus-navigation-height flex h-full w-full flex-col">
-      <CategorySlider categories={categories} />
-      <div className="py-space-y">{children}</div>
-    </div>
-  )
+  return <CategorySlider categories={categories} />
 }
 
 export default function Layout({
@@ -26,8 +17,11 @@ export default function Layout({
   children: React.ReactNode
 }>) {
   return (
-    <Suspense>
-      <CategorySliderLayout>{children}</CategorySliderLayout>
-    </Suspense>
+    <div className="min-h-screen-minus-navigation-height flex h-full w-full flex-col">
+      <Suspense>
+        <CategorySliderLayout />
+      </Suspense>
+      <div className="py-space-y">{children}</div>
+    </div>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next"
 import localFont from "next/font/local"
-import { Suspense } from "react"
 
 import Footer from "@/components/global/footer/Footer"
 import GridHelper from "@/components/global/gridHelper/GridHelper"
@@ -8,7 +7,6 @@ import Header from "@/components/global/header/Header"
 import Theme from "@/components/global/theme/Theme"
 import { DynamicModal } from "@/components/shared/dynamicModal/DynamicModal"
 import { DynamicSheet } from "@/components/shared/dynamicSheet/DynamicSheet"
-import { getDplCmsPublicConfig } from "@/lib/config/dpl-cms/dplCmsConfig"
 import { setLayoutMetadata } from "@/lib/helpers/helper.metadata"
 import DplCmsConfigContextProvider from "@/lib/providers/DplCmsConfigContextProvider"
 import ReactQueryProvider from "@/lib/providers/ReactQueryProvider"
@@ -32,40 +30,28 @@ const GTFlexa = localFont({
   display: "swap",
 })
 
-async function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode
-}>) {
-  const dplCmsConfig = await getDplCmsPublicConfig()
-  return (
-    <html lang="da">
-      <body className={`${GTFlexa.variable} duration-dark-mode antialiased transition-all`}>
-        <GridHelper hideInProduction />
-        <DplCmsConfigContextProvider config={dplCmsConfig}>
-          <Theme>
-            <ReactQueryProvider>
-              <Header />
-              <DynamicSheet />
-              <DynamicModal />
-              {children}
-              <Footer />
-            </ReactQueryProvider>
-          </Theme>
-        </DplCmsConfigContextProvider>
-      </body>
-    </html>
-  )
-}
-
 export default function Layout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
   return (
-    <Suspense>
-      <RootLayout>{children}</RootLayout>
-    </Suspense>
+    <html lang="da">
+      <body className={`${GTFlexa.variable} duration-dark-mode antialiased transition-all`}>
+        <GridHelper hideInProduction />
+
+        <Theme>
+          <ReactQueryProvider>
+            <Header />
+            <DplCmsConfigContextProvider>
+              <DynamicSheet />
+            </DplCmsConfigContextProvider>
+            <DynamicModal />
+            {children}
+            <Footer />
+          </ReactQueryProvider>
+        </Theme>
+      </body>
+    </html>
   )
 }

--- a/lib/providers/DplCmsConfigContextProvider.tsx
+++ b/lib/providers/DplCmsConfigContextProvider.tsx
@@ -3,17 +3,32 @@
 import { createContext } from "react"
 
 import { TDplCmsPublicConfig } from "../config/dpl-cms/configSchemas"
+import { useGetDplCmsPublicConfigurationQuery } from "../graphql/generated/dpl-cms/graphql"
 
 export const DplCmsConfigContext = createContext<TDplCmsPublicConfig | null>(null)
 
-export default function DplCmsConfigContextProvider({
-  children,
-  config,
-}: {
-  children: React.ReactNode
-  config: TDplCmsPublicConfig | null
-}) {
+export default function DplCmsConfigContextProvider({ children }: { children: React.ReactNode }) {
+  const { data } = useGetDplCmsPublicConfigurationQuery()
+  const goConfiguration = data?.goConfiguration?.public
+    ? {
+        loginUrls: {
+          adgangsplatformen: data.goConfiguration.public.loginUrls?.adgangsplatformen ?? null,
+        },
+        logoutUrls: {
+          adgangsplatformen: data.goConfiguration.public.logoutUrls?.adgangsplatformen ?? null,
+        },
+        libraryInfo: {
+          name: data.goConfiguration.public.libraryInfo?.name ?? null,
+        },
+        unilogin: {
+          municipalityId: data.goConfiguration.public.unilogin?.municipalityId ?? null,
+        },
+      }
+    : null
+
   return (
-    <DplCmsConfigContext.Provider value={config ?? null}>{children}</DplCmsConfigContext.Provider>
+    <DplCmsConfigContext.Provider value={goConfiguration || null}>
+      {children}
+    </DplCmsConfigContext.Provider>
   )
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-639

#### Description

This PR introduces an adjustment of the usage of the suspense wrapper to prevent layout shifts and ensure that certain components do not wait for irrelevant requests from ⁠dpl-cms before rendering.