### PR TITLE
Use lagoon env variables for cms routes

### DIFF
--- a/lagoon/start.sh
+++ b/lagoon/start.sh
@@ -23,31 +23,11 @@ if [ -z "$app_url" ]; then
   exit 1
 fi
 
-# Make sure the DPL CMS graphql schema endpoint is set in application
-goCmsUrlPrefix="nginx."
-# If the project is "dpl-cms", we are running in a PR environment
-# and then the goUrlPrefix should be cms-.
-# Otherwise we are in production and the goUrlPrefix should be "nginx.".
-if [ "$LAGOON_PROJECT" = "dpl-cms" ]; then
-  goCmsUrlPrefix="cms-"
-fi
-cms_url=$(getLagoonUrl $goCmsUrlPrefix)
-if [ -z "$cms_url" ]; then
-  echo "Error: Unable to determine CMS URL"
-  exit 1
-fi
-
-# Remove the protocol from the URL
-removeProtocol() {
-  local url=$1
-  echo "${url#*://}" | sed 's:/*$::'
-}
-
 # Set the environment variables.
 # These ones are varying from environment to environment.
 export NEXT_PUBLIC_APP_URL="$app_url"
-export NEXT_PUBLIC_DPL_CMS_HOSTNAME=$(removeProtocol "$cms_url")
-export NEXT_PUBLIC_GRAPHQL_SCHEMA_ENDPOINT_DPL_CMS="$cms_url/graphql"
+export NEXT_PUBLIC_DPL_CMS_HOSTNAME="${LAGOON_DOMAIN}"
+export NEXT_PUBLIC_GRAPHQL_SCHEMA_ENDPOINT_DPL_CMS="${LAGOON_ROUTE}/graphql"
 
 # Go to the app directory if it doesn't exist then never mind.
 cd /app || exit 1


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-582

#### Description
Use lagoon env variables for cms routes
In the docker file we can make use of LAGOON_ROUTE which always point to the cms. And LAGOON_DOMAIN seems to be the same without the protocol.

