### PR TITLE
Make sure that APP_URL is based upon the Lagoon primary url (dpl-cms)

### DIFF
--- a/lagoon/start.sh
+++ b/lagoon/start.sh
@@ -1,31 +1,6 @@
-getLagoonUrl() {
-  local type=$1
-
-  for route in ${LAGOON_ROUTES//,/ }; do
-    if echo "$route" | grep -q "$type"; then
-      echo "$route"
-      return
-    fi
-  done
-}
-
-# Make sure app.url is set in application
-goUrlPrefix="go."
-# If the project is "dpl-cms", we are running in a PR environment
-# and then the goUrlPrefix should be go-.
-# Otherwise we are in production and the goUrlPrefix should be "go.".
-if [ "$LAGOON_PROJECT" = "dpl-cms" ]; then
-  goUrlPrefix="go-"
-fi
-app_url=$(getLagoonUrl $goUrlPrefix)
-if [ -z "$app_url" ]; then
-  echo "Error: Unable to determine app URL"
-  exit 1
-fi
-
 # Set the environment variables.
 # These ones are varying from environment to environment.
-export NEXT_PUBLIC_APP_URL="$app_url"
+export NEXT_PUBLIC_APP_URL="https://go.${LAGOON_DOMAIN}"
 export NEXT_PUBLIC_DPL_CMS_HOSTNAME="${LAGOON_DOMAIN}"
 export NEXT_PUBLIC_GRAPHQL_SCHEMA_ENDPOINT_DPL_CMS="${LAGOON_ROUTE}/graphql"
 


### PR DESCRIPTION

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description
Make sure that APP_URL is based upon the Lagoon primary url (dpl-cms)
Whatever Lagoon decides the primary domain is, go is a subdomain of that.
