### PR TITLE
Lazy load images and iframes

### DIFF
--- a/components/paragraphs/Video/Video.tsx
+++ b/components/paragraphs/Video/Video.tsx
@@ -31,7 +31,9 @@ const Video = (Video: VideoProps) => {
             className="absolute inset-0 h-full w-full"
             src={embedVideo?.mediaVideotool}
             allowFullScreen
-            allow="autoplay; fullscreen"></iframe>
+            allow="autoplay; fullscreen"
+            loading="lazy"
+          />
         </div>
       </div>
     </div>

--- a/components/paragraphs/VideoBundle/VideoBundle.tsx
+++ b/components/paragraphs/VideoBundle/VideoBundle.tsx
@@ -59,6 +59,7 @@ const VideoBundle = ({ works, title, videoUrl }: VideoBundleProps) => {
                 src={videoUrl}
                 allowFullScreen
                 allow="autoplay; fullscreen"
+                loading="lazy"
               />
             </div>
             <div

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -51,8 +51,6 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
             <img
               src={covers.thumbnail}
               alt={alt}
-              height={imageHeight}
-              width={imageWidth}
               sizes="20px"
               loading="lazy"
               className={cn(
@@ -68,9 +66,6 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
               srcSet={`${covers.xSmall?.url} 120w, ${covers.small?.url} 240w, ${covers.medium?.url} 480w, ${covers.large?.url} 960w`}
               sizes="(max-width: 500px) 110px, (max-width: 1024px) 230px, 320px"
               alt={alt}
-              height={imageHeight}
-              width={imageWidth}
-              sizes="100vw"
               loading="lazy"
               className={cn(
                 `shadow-cover-picture absolute inset-0 h-auto w-full overflow-hidden rounded-sm object-contain

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -51,6 +51,9 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
             <img
               src={covers.thumbnail}
               alt={alt}
+              height={imageHeight}
+              width={imageWidth}
+              sizes="20px"
               loading="lazy"
               className={cn(
                 `absolute inset-0 h-auto w-full overflow-hidden rounded-sm object-contain transition-all duration-500
@@ -65,6 +68,9 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
               srcSet={`${covers.xSmall?.url} 120w, ${covers.small?.url} 240w, ${covers.medium?.url} 480w, ${covers.large?.url} 960w`}
               sizes="(max-width: 500px) 110px, (max-width: 1024px) 230px, 320px"
               alt={alt}
+              height={imageHeight}
+              width={imageWidth}
+              sizes="100vw"
               loading="lazy"
               className={cn(
                 `shadow-cover-picture absolute inset-0 h-auto w-full overflow-hidden rounded-sm object-contain

--- a/components/shared/image/ImageBase.tsx
+++ b/components/shared/image/ImageBase.tsx
@@ -20,7 +20,7 @@ export type TImageBaseProps = {
 export default function ImageBase({
   imageSizing = "intrinsic",
   src,
-  sizes = "100vw",
+  sizes = "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw",
   priority = false,
   className,
   width,
@@ -46,6 +46,7 @@ export default function ImageBase({
           height={height}
           alt={alt}
           onLoad={() => setImageLoaded(true)}
+          loading="lazy"
           style={
             base64
               ? {
@@ -75,6 +76,7 @@ export default function ImageBase({
           height={height}
           alt={alt}
           onLoad={() => setImageLoaded(true)}
+          loading="lazy"
           style={
             base64
               ? {

--- a/components/shared/publizonPlayer/PublizonPlayer.tsx
+++ b/components/shared/publizonPlayer/PublizonPlayer.tsx
@@ -35,6 +35,7 @@ const Player = ({ type, orderId, identifier }: ReaderType) => {
         src={`https://play.pubhub.dk/index141.html?o=${orderId}`}
         style={{ height: "300px" }}
         className="player h-full w-full"
+        loading="lazy"
       />
     )
   }
@@ -46,6 +47,7 @@ const Player = ({ type, orderId, identifier }: ReaderType) => {
         src={`https://play.pubhub.dk/index141.html?i=${identifier}`}
         style={{ height: "300px" }}
         className="player rounded-base h-full w-full"
+        loading="lazy"
       />
     )
   }

--- a/cypress/e2e/frontpage.cy.ts
+++ b/cypress/e2e/frontpage.cy.ts
@@ -33,7 +33,7 @@ describe("Front Page Tests", () => {
       cy.dataCy("video-bundle-next-button").click()
 
       cy.dataCy("work-card-title")
-        .eq(1)
+        .first()
         .should("be.visible")
         .should("contain.text", "Dette er titlen på en lydbog")
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-701

#### Description

To improve performance on pages with a lot of pictures, it is necessary to lazy load images only when they appear in the browser viewport. 
This can also be done for iframes, which are uses to display vidoes.

We also discovered that for every rerender of the `WorkCardStackedWithCaption.tsx` component, it would re-fetch all images for each pagination in the carousel. By refactoring it, we only render the currently shown material cover. 