### PR TITLE
Use cover object to generate `srcset` to load directly from FBI

### DIFF
--- a/app/(pages)/user/profile/LoanCard.tsx
+++ b/app/(pages)/user/profile/LoanCard.tsx
@@ -17,9 +17,6 @@ import {
   ManifestationWorkPageFragment,
 } from "@/lib/graphql/generated/fbi/graphql"
 import { cn } from "@/lib/helpers/helper.cn"
-import { getCoverUrls, getLowResCoverUrl } from "@/lib/helpers/helper.covers"
-import { useGetCoverCollection } from "@/lib/rest/cover-service-api/generated/cover-service"
-import { GetCoverCollectionSizesItem } from "@/lib/rest/cover-service-api/generated/model"
 import { useGetV1ProductsIdentifierAdapter } from "@/lib/rest/publizon/adapter/generated/publizon"
 import useGetV1UserLoans from "@/lib/rest/publizon/useGetV1UserLoans"
 
@@ -39,23 +36,12 @@ const LoanCard = ({
   setEbookLoans,
 }: LoanCardProps) => {
   const { data: dataLoans, isLoading: isLoadingLoans } = useGetV1UserLoans()
-  const { data: dataCovers, isLoading: isLoadingCovers } = useGetCoverCollection({
-    type: "pid",
-    identifiers: [manifestation.pid],
-    sizes: [
-      "xx-small, small, small-medium, medium, medium-large, large, original, default" as GetCoverCollectionSizesItem,
-    ],
-  })
+
   const manifestationIsbn = manifestation.identifiers.find(
     identifier => identifier.type === "ISBN"
   )?.value
   const { data: dataProducts } = useGetV1ProductsIdentifierAdapter(manifestationIsbn || "")
-  const lowResCover = getLowResCoverUrl(dataCovers)
-  const coverSrc = getCoverUrls(
-    dataCovers,
-    [manifestation.pid],
-    ["default", "original", "large", "medium-large", "medium", "small-medium", "small", "xx-small"]
-  )
+
   const loan = dataLoans?.loans?.find(loan => loan.libraryBook?.identifier === manifestationIsbn)
   const targetDate = new Date(loan?.loanExpireDateUtc || "")
   const today = new Date()
@@ -91,7 +77,7 @@ const LoanCard = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [manifestation, isCostFree, dataProducts])
 
-  if (isLoadingCovers || isLoadingLoans) {
+  if (isLoadingLoans) {
     return (
       <div className={cn("relative flex aspect-5/7 h-full w-full", className)}>
         <div className="aspect-1/1 h-full w-full p-14">
@@ -107,8 +93,7 @@ const LoanCard = ({
         <div className="block h-full w-full space-y-3 px-[15%]">
           <div className="relative h-[85%]">
             <CoverPicture
-              lowResSrc={lowResCover || ""}
-              src={coverSrc?.[0] || ""}
+              covers={manifestation.cover}
               alt={`${title} cover billede`}
               withTilt={false}
               className="select-none"

--- a/components/pages/workPageLayout/WorkPageHeader.tsx
+++ b/components/pages/workPageLayout/WorkPageHeader.tsx
@@ -59,8 +59,7 @@ const WorkPageHeader = ({ manifestations, work, selectedManifestation }: WorkPag
     }
   )
 
-  const coverSrc = selectedManifestation.cover.large?.url
-  const lowResCoverSrc = selectedManifestation.cover.thumbnail
+  const covers = selectedManifestation.cover
 
   const onOptionSelect = (optionSelected: SlideSelectOption) => {
     const url = resolveUrl({
@@ -94,13 +93,7 @@ const WorkPageHeader = ({ manifestations, work, selectedManifestation }: WorkPag
         exit={{ opacity: 0 }}>
         <div className="col-span-4 h-auto lg:order-2">
           <div className="rounded-base flex aspect-1/1 h-auto w-full flex-col items-center justify-center lg:aspect-4/5">
-            {coverSrc && lowResCoverSrc && (
-              <CoverPicture
-                alt="Forsidebillede på værket"
-                lowResSrc={lowResCoverSrc || ""}
-                src={coverSrc || ""}
-              />
-            )}
+            {covers && <CoverPicture alt="Forsidebillede på værket" covers={covers} />}
           </div>
           {slideSelectOptions && (
             <div className="flex w-full justify-center pt-12">

--- a/components/shared/coverPicture/CoverPicture.stories.tsx
+++ b/components/shared/coverPicture/CoverPicture.stories.tsx
@@ -2,11 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import { darkModeDecorator } from "@/.storybook/decorators"
 import { CoverPicture } from "@/components/shared/coverPicture/CoverPicture"
+import { coverFactory } from "@/cypress/factories/fbi/factory-parts/cover"
 
 const defaultArgs = {
-  src: "https://res.cloudinary.com/dandigbib/image/upload/v1544470826/saxo.dk/9788762722880.jpg",
-  lowResSrc:
-    "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_xxs/v1544470826/saxo.dk/9788762722880.jpg",
+  covers: coverFactory.build(),
   alt: "Cover picture alt text",
 }
 
@@ -17,11 +16,8 @@ const meta = {
     layout: "centered",
   },
   argTypes: {
-    lowResSrc: {
-      control: { type: "text" },
-    },
-    src: {
-      control: { type: "text" },
+    covers: {
+      control: { type: "object" },
     },
     alt: {
       control: { type: "text" },
@@ -79,7 +75,7 @@ export const WithTiltDarkMode: Story = {
 }
 
 export const WithoutCover: Story = {
-  args: { ...defaultArgs, src: "", lowResSrc: "" },
+  args: { ...defaultArgs, covers: {} },
   render: args => (
     <div
       className="rounded-base flex aspect-1/1 h-auto w-[90vw] flex-col items-center justify-center lg:aspect-4/5
@@ -90,7 +86,7 @@ export const WithoutCover: Story = {
 }
 
 export const WithoutCoverDarkMode: Story = {
-  args: { ...defaultArgs, src: "", lowResSrc: "" },
+  args: { ...defaultArgs, covers: {} },
   decorators: [darkModeDecorator],
   render: args => (
     <div

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -1,30 +1,21 @@
 import { useWindowSize } from "@uidotdev/usehooks"
 import { motion } from "framer-motion"
-import Image from "next/image"
 import React, { useEffect, useRef, useState } from "react"
 import Tilt from "react-parallax-tilt"
 
 import Icon from "@/components/shared/icon/Icon"
+import { Cover } from "@/lib/graphql/generated/fbi/graphql"
 import { cn } from "@/lib/helpers/helper.cn"
 
 type CoverPictureProps = {
-  lowResSrc: string
-  src: string
+  covers: Cover
   className?: string
   alt: string
   withTilt?: boolean
 }
-export const CoverPicture = ({
-  src,
-  lowResSrc,
-  alt,
-  withTilt = false,
-  className,
-}: CoverPictureProps) => {
+export const CoverPicture = ({ covers, alt, withTilt = false, className }: CoverPictureProps) => {
   const size = useWindowSize()
-  const [imageHeight, setImageHeight] = useState(0)
-  const [imageWidth, setImageWidth] = useState(0)
-  const imageAspectRatio = imageWidth / imageHeight
+  const imageAspectRatio = (covers.large?.width ?? 0) / (covers.large?.height ?? 0)
 
   // get the container height
   const ref = useRef<HTMLDivElement>(null)
@@ -50,41 +41,31 @@ export const CoverPicture = ({
 
   return (
     <div className={cn("flex h-full w-full items-center", className)} ref={ref}>
-      {!imageError && src ? (
+      {!imageError && covers.thumbnail ? (
         <CoverPictureTiltWrapper
           withTilt={withTilt}
           className={"relative m-auto"}
           style={{ paddingTop, width: `${imageWidthByContainerHeight}px` }}>
-          {lowResSrc && (
-            <Image
-              src={lowResSrc}
+          {covers.thumbnail && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={covers.thumbnail}
               alt={alt}
-              height={imageHeight}
-              width={imageWidth}
-              sizes="20px"
-              loading="eager"
+              loading="lazy"
               className={cn(
                 `absolute inset-0 h-auto w-full overflow-hidden rounded-sm object-contain transition-all duration-500
                   will-change-transform`,
                 imageLoaded ? "shadow-none" : "shadow-cover-picture"
               )}
-              onLoad={({ target }) => {
-                // get the intrinsic dimensions of the image
-                const { naturalWidth, naturalHeight } = target as HTMLImageElement
-
-                setImageHeight(naturalHeight)
-                setImageWidth(naturalWidth)
-              }}
             />
           )}
-          {src && (
-            <Image
-              src={src}
+          {covers.large && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              srcSet={`${covers.xSmall?.url} 120w, ${covers.small?.url} 240w, ${covers.medium?.url} 480w, ${covers.large?.url} 960w`}
+              sizes="(max-width: 500px) 110px, (max-width: 1024px) 230px, 320px"
               alt={alt}
-              height={imageHeight}
-              width={imageWidth}
-              sizes="100vw"
-              loading="eager"
+              loading="lazy"
               className={cn(
                 `shadow-cover-picture absolute inset-0 h-auto w-full overflow-hidden rounded-sm object-contain
                   transition-all duration-500 will-change-transform`,

--- a/components/shared/loanMaterialModal/LoanMaterialModal.tsx
+++ b/components/shared/loanMaterialModal/LoanMaterialModal.tsx
@@ -6,16 +6,13 @@ import {
   getManifestationMaterialTypeSpecific,
 } from "@/components/pages/workPageLayout/helper"
 import { Button } from "@/components/shared/button/Button"
-import { CoverPicture, CoverPictureSkeleton } from "@/components/shared/coverPicture/CoverPicture"
+import { CoverPicture } from "@/components/shared/coverPicture/CoverPicture"
 import Icon from "@/components/shared/icon/Icon"
 import ResponsiveDialog from "@/components/shared/responsiveDialog/ResponsiveDialog"
 import MaterialTypeIconWrapper from "@/components/shared/workCard/MaterialTypeIconWrapper"
 import { ManifestationWorkPageFragment } from "@/lib/graphql/generated/fbi/graphql"
 import { cn } from "@/lib/helpers/helper.cn"
-import { getCoverUrls, getLowResCoverUrl } from "@/lib/helpers/helper.covers"
 import { getIsbnsFromManifestation } from "@/lib/helpers/ids"
-import { useGetCoverCollection } from "@/lib/rest/cover-service-api/generated/cover-service"
-import { GetCoverCollectionSizesItem } from "@/lib/rest/cover-service-api/generated/model"
 import { ApiResponseCode } from "@/lib/rest/publizon/local-adapter/generated/model"
 import usePostV1UserLoansIdentifier from "@/lib/rest/publizon/usePostV1UserLoansIdentifier"
 import { modalStore } from "@/store/modal.store"
@@ -30,28 +27,7 @@ const LoanMaterialModal = ({
   manifestation: ManifestationWorkPageFragment
 }) => {
   const queryClient = useQueryClient()
-  const { data: dataCovers, isLoading: isLoadingCovers } = useGetCoverCollection(
-    {
-      type: "pid",
-      // This is always a string - query is disabled when selectedManifestation is false-y
-      identifiers: [manifestation.pid as string],
-      sizes: [
-        "xx-small, small, small-medium, medium, medium-large, large, original, default" as GetCoverCollectionSizesItem,
-      ],
-    },
-    { query: { enabled: !!manifestation.pid } }
-  )
-  const lowResCover = getLowResCoverUrl(dataCovers)
-  const coverSrc = getCoverUrls(dataCovers, manifestation?.pid ? [manifestation.pid] : undefined, [
-    "default",
-    "original",
-    "large",
-    "medium-large",
-    "medium",
-    "small-medium",
-    "small",
-    "xx-small",
-  ])
+
   const { mutate } = usePostV1UserLoansIdentifier()
   const isbns = getIsbnsFromManifestation(manifestation)
   const [isHandlingLoan, setIsHandlingLoan] = useState(false)
@@ -87,16 +63,7 @@ const LoanMaterialModal = ({
       open={open}
       title={`Lån ${getManifestationMaterialTypeSpecific(manifestation) || "materialet"}`}>
       <div className="rounded-base relative flex aspect-1/1 h-36 w-full flex-col items-center justify-center lg:aspect-4/5">
-        {isLoadingCovers && (
-          <div className="aspect-1/1 h-36 lg:aspect-4/5">
-            <CoverPictureSkeleton />
-          </div>
-        )}
-        <CoverPicture
-          alt="Forsidebillede på værket"
-          lowResSrc={lowResCover || ""}
-          src={coverSrc?.[0] || ""}
-        />
+        <CoverPicture alt="Forsidebillede på værket" covers={manifestation.cover} />
         <MaterialTypeIconWrapper
           iconName={getManifestationMaterialTypeIcon(manifestation)}
           className="bg-background absolute -bottom-6 h-10 w-10 outline-1"

--- a/components/shared/workCard/WorkCard.tsx
+++ b/components/shared/workCard/WorkCard.tsx
@@ -60,8 +60,7 @@ const WorkCard = ({
     },
   })
 
-  const coverSrc = bestRepresentation.cover.large?.url
-  const lowResCoverSrc = bestRepresentation.cover.thumbnail
+  const covers = bestRepresentation.cover
 
   const isSomeMaterialTypePodcast = manifestationsWithPublizonData.some(
     manifestation => manifestation.materialTypes[0].materialTypeGeneral.code === "PODCASTS"
@@ -87,10 +86,9 @@ const WorkCard = ({
       ) : null}
       <div className="relative mx-auto flex aspect-5/7 h-full w-full">
         <div className="h-full w-full">
-          {coverSrc && lowResCoverSrc && (
+          {covers && (
             <CoverPicture
-              lowResSrc={lowResCoverSrc}
-              src={coverSrc}
+              covers={covers}
               alt={`${title} cover billede`}
               withTilt={isWithTilt}
               className="select-none"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-700

#### Description

This PR changes the image element in `CoverPicture.tsx` to use a simple `<img>` element instead of the cached <Image>.
By doing this, we also need to generate our own `srcset`, by using the different size variants coming from FBI. 
This also requires the component to receive the full covers object.

