### PR TITLE
Revert "Remove unnecessary dynamic export declarations from various route files"

### DIFF
--- a/app/(routes)/auth/callback/adgangsplatformen/route.ts
+++ b/app/(routes)/auth/callback/adgangsplatformen/route.ts
@@ -19,3 +19,5 @@ export async function GET() {
   console.error("Could not retrieve Adgangsplatformen user token.")
   return NextResponse.redirect(`${getEnv("APP_URL")}/${goConfig("routes.login-failed-ap")}`)
 }
+
+export const dynamic = "force-dynamic"

--- a/app/(routes)/auth/callback/unilogin/route.ts
+++ b/app/(routes)/auth/callback/unilogin/route.ts
@@ -144,3 +144,5 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.redirect(`${getEnv("APP_URL")}/user/profile`)
 }
+
+export const dynamic = "force-dynamic"

--- a/app/(routes)/auth/login/unilogin/route.ts
+++ b/app/(routes)/auth/login/unilogin/route.ts
@@ -30,3 +30,5 @@ export async function GET() {
 
   return Response.redirect(redirectTo)
 }
+
+export const dynamic = "force-dynamic"

--- a/app/(routes)/auth/logout/route.ts
+++ b/app/(routes)/auth/logout/route.ts
@@ -15,3 +15,5 @@ export async function GET() {
 
   return destroySessionAndRedirectToFrontPage(session)
 }
+
+export const dynamic = "force-dynamic"

--- a/app/(routes)/pubhub/v1/library/profile/route.ts
+++ b/app/(routes)/pubhub/v1/library/profile/route.ts
@@ -40,3 +40,5 @@ async function getLibraryProfile() {
 }
 
 export const GET = withAuth(getLibraryProfile)
+
+export const dynamic = "force-dynamic"

--- a/app/(routes)/pubhub/v1/user/loans/[identifier]/route.ts
+++ b/app/(routes)/pubhub/v1/user/loans/[identifier]/route.ts
@@ -47,3 +47,5 @@ async function createdigitalLoan(
 }
 
 export const POST = withAuth(createdigitalLoan)
+
+export const dynamic = "force-dynamic"

--- a/app/(routes)/pubhub/v1/user/loans/route.ts
+++ b/app/(routes)/pubhub/v1/user/loans/route.ts
@@ -54,3 +54,5 @@ async function getLibraryUserOrder(request: NextRequest, context: { uniLoginUser
 }
 
 export const GET = withAuth(getLibraryUserOrder)
+
+export const dynamic = "force-dynamic"


### PR DESCRIPTION
Reverts danskernesdigitalebibliotek/dpl-go#263 because it breaks unilogin