### PR TITLE
Too many requests against cms api

### DIFF
--- a/app/(pages)/user/profile/LoanSlider.tsx
+++ b/app/(pages)/user/profile/LoanSlider.tsx
@@ -92,6 +92,7 @@ const LoanSlider = ({ works, loanData }: LoanSliderProps) => {
             const loanManifestation = work.manifestations.all[0]
             return (
               <Link
+                prefetch={false}
                 key={loanManifestation.pid}
                 aria-label={`Tilgå værket ${work.titles.full[0]} af ${displayCreators(work.creators, 1)}`}
                 className={cn(

--- a/components/pages/searchPageLayout/SearchResults.tsx
+++ b/components/pages/searchPageLayout/SearchResults.tsx
@@ -53,6 +53,7 @@ const SearchResults = ({ works }: SearchResultProps) => {
         return (
           <div key={work.workId} className="col-span-3 lg:col-span-4">
             <Link
+              prefetch={false}
               aria-label={`Tilgå værket ${title} af ${displayCreators(work.creators, 1)}`}
               className="focus-visible"
               href={url}>

--- a/components/paragraphs/MaterialSlider/MaterialSlider.tsx
+++ b/components/paragraphs/MaterialSlider/MaterialSlider.tsx
@@ -126,6 +126,7 @@ const MaterialSlider = ({ works, title }: MaterialSliderProps) => {
 
                   return (
                     <Link
+                      prefetch={false}
                       key={work.workId}
                       aria-label={`Tilgå værket ${title} af ${displayCreators(work.creators, 1)}`}
                       className="keen-slider__slide focus-visible outline-accent-foreground focus:outline-offset-2"

--- a/components/paragraphs/ParagraphGoLinkbox/ParagraphGoLinkbox.tsx
+++ b/components/paragraphs/ParagraphGoLinkbox/ParagraphGoLinkbox.tsx
@@ -78,6 +78,7 @@ function ParagraphGoLinkbox(paragraphGoLinkboxProps: TParagraphGoLinkboxProps) {
             {linkUrl && linkTitle && (
               <Button asChild>
                 <Link
+                  prefetch={false}
                   title={linkTitle}
                   href={linkUrl}
                   area-label={areaLabel || linkTitle}

--- a/components/shared/smartLink/SmartLink.tsx
+++ b/components/shared/smartLink/SmartLink.tsx
@@ -17,7 +17,7 @@ function SmartLink({
   // Internal link
   if (linkType === "internal") {
     return (
-      <Link className={className} href={href} target={target}>
+      <Link className={className} href={href} target={target} prefetch={false}>
         {children}
       </Link>
     )

--- a/components/shared/workCard/WorkCardStackedWithCaption.tsx
+++ b/components/shared/workCard/WorkCardStackedWithCaption.tsx
@@ -84,7 +84,8 @@ const WorkCardStackedWithCaption = ({
         aria-label={`Tilgå værket ${title} af ${displayCreators(currentWork.creators, 1)}`}
         className="focus-visible block h-full w-full space-y-3 lg:space-y-5"
         href={url}
-        style={{ zIndex }}>
+        style={{ zIndex }}
+        prefetch={false}>
         <WorkCardWithCaption
           creators={currentWork.creators || []}
           title={title}

--- a/lib/helpers/library-token.ts
+++ b/lib/helpers/library-token.ts
@@ -23,7 +23,7 @@ export const loadLibraryToken = async () => {
       .safeParse(data?.dplTokens?.adgangsplatformen?.library)
 
     if (validateLibraryToken.error) {
-      console.error(validateLibraryToken.error)
+      console.error("Error parsing library token:", validateLibraryToken.error.flatten())
       return null
     }
     return validateLibraryToken.data

--- a/lib/helpers/user-token.ts
+++ b/lib/helpers/user-token.ts
@@ -28,7 +28,7 @@ export const loadUserToken = async () => {
       .safeParse(data?.dplTokens?.adgangsplatformen?.user)
 
     if (validateUserToken.error) {
-      console.error(validateUserToken.error.flatten)
+      console.error(validateUserToken.error.flatten())
       return null
     }
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-722

#### Description

There are too many requests hitting the dpl-cms API. It is mainly user token and library token request coming from the middleware. 
I tried to solve it with identifying the type of requests coming to the middleware. But it is not possible to distinguish between navigating around on the page from prefetch requests. Only the very first request to the document is possible to identify.
The solution was to disable prefetching where the `Link` component is used.
