### PR TITLE
Remove-cypress-only

### DIFF
--- a/cypress/e2e/login-logout.cy.ts
+++ b/cypress/e2e/login-logout.cy.ts
@@ -124,7 +124,7 @@ describe("UNI•Login: Login / Logout API Tests", () => {
   })
 })
 
-describe.only("Adgangsplatformen: Login / Logout API Tests", () => {
+describe("Adgangsplatformen: Login / Logout API Tests", () => {
   const performLoginCallback = () => {
     const mockedCallbackUrl = "/auth/callback/adgangsplatformen"
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,6 +59,24 @@ const eslintConfig = [
           message:
             "Beware that setViewport should only be used while debugging Cypress locally. Otherwise it forces the viewport to a fixed size, which is not what we want for responsive testing.",
         },
+        {
+          object: "describe",
+          property: "only",
+          message:
+            "describe.only() should not be used in production code. Remove .only() to run all tests.",
+        },
+        {
+          object: "it",
+          property: "only",
+          message:
+            "it.only() should not be used in production code. Remove .only() to run all tests.",
+        },
+        {
+          object: "test",
+          property: "only",
+          message:
+            "test.only() should not be used in production code. Remove .only() to run all tests.",
+        },
       ],
       "no-restricted-syntax": [
         "error",


### PR DESCRIPTION
Remove .only() from login/logout test and setup eslint warning rule