### PR TITLE
fix: only cache response if data is returned from CMS

### DIFF
--- a/app/(pages)/artikel/[...slug]/page.tsx
+++ b/app/(pages)/artikel/[...slug]/page.tsx
@@ -1,3 +1,4 @@
+import { isEmpty } from "lodash"
 import { cacheTag } from "next/dist/server/use-cache/cache-tag"
 import React, { Suspense } from "react"
 
@@ -17,6 +18,10 @@ async function getPage(slug: string[]) {
     contentPath: slug.join("/"),
     type: "article",
   })
+
+  if (isEmpty(data)) {
+    notFound()
+  }
 
   if (cacheTags) {
     // eslint-disable-next-line no-console

--- a/app/(pages-with-category-slider)/[[...slug]]/page.tsx
+++ b/app/(pages-with-category-slider)/[[...slug]]/page.tsx
@@ -1,4 +1,6 @@
+import { isEmpty } from "lodash"
 import { cacheTag } from "next/dist/server/use-cache/cache-tag"
+import { notFound } from "next/navigation"
 import React, { Suspense } from "react"
 
 import RedirectNotFoundOrRenderPage from "@/components/global/dplCmsPage/RedirectNotFoundOrRenderPage"
@@ -17,6 +19,10 @@ async function getPage(slug: string[]) {
     contentPath: slug ? slug.join("/") : goConfig("routes.frontpage"),
     type: "page",
   })
+
+  if (isEmpty(data)) {
+    notFound()
+  }
 
   if (cacheTags) {
     // eslint-disable-next-line no-console

--- a/app/(pages-with-category-slider)/kategori/[...slug]/page.tsx
+++ b/app/(pages-with-category-slider)/kategori/[...slug]/page.tsx
@@ -1,3 +1,4 @@
+import { isEmpty } from "lodash"
 import { cacheTag } from "next/dist/server/use-cache/cache-tag"
 import React, { Suspense } from "react"
 
@@ -16,6 +17,10 @@ async function getPage(slug: string[]) {
     contentPath: slug.join("/"),
     type: "category",
   })
+
+  if (isEmpty(data)) {
+    notFound()
+  }
 
   if (cacheTags) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-298

#### Description

This PR resolves the issue with cached 404 pages and prevents Next.js from generating cache tags when CMS data is missing.
