### PR TITLE
feat: add health status route with version and frontpage data checks

### DIFF
--- a/app/(routes)/health/route.ts
+++ b/app/(routes)/health/route.ts
@@ -1,0 +1,61 @@
+import { promises as fs } from "fs"
+import { isEmpty } from "lodash"
+import { NextResponse } from "next/server"
+
+import goConfig from "@/lib/config/goConfig"
+import { loadPageData } from "@/lib/helpers/dpl-cms-content"
+
+type HealthStatusRequestBody = {
+  version: string
+  requests: {
+    [key: string]: {
+      status: "ok" | "error"
+      message: string
+    }
+  }
+}
+
+async function getHealthStatus() {
+  const requestBody: HealthStatusRequestBody = {
+    version: "",
+    requests: {},
+  }
+
+  try {
+    // Get version from .version json file in root of project. .version file should only exist in lagoon.
+    const jsonFile = await fs.readFile(".version", "utf8")
+    requestBody.version = JSON.parse(jsonFile).version
+  } catch (error) {
+    requestBody.version = `Error reading version: ${error instanceof Error ? error.message : "Unknown error"}`
+  }
+
+  try {
+    const frontpageData = await loadPageData({
+      contentPath: goConfig("routes.frontpage"),
+      type: "page",
+    })
+
+    if (!isEmpty(frontpageData)) {
+      requestBody.requests.frontpage = {
+        status: "ok",
+        message: "Frontpage data loaded successfully",
+      }
+    } else {
+      requestBody.requests.frontpage = {
+        status: "error",
+        message: `Frontpage data is empty`,
+      }
+    }
+  } catch (error) {
+    requestBody.requests.frontpage = {
+      status: "error",
+      message: `Error loading frontpage data: ${error instanceof Error ? error.message : "Unknown error"}`,
+    }
+  }
+
+  return NextResponse.json(requestBody, { status: 200 })
+}
+
+export const GET = getHealthStatus
+
+export const dynamic = "force-dynamic"

--- a/app/(routes)/health/route.ts
+++ b/app/(routes)/health/route.ts
@@ -5,20 +5,22 @@ import { NextResponse } from "next/server"
 import goConfig from "@/lib/config/goConfig"
 import { loadPageData } from "@/lib/helpers/dpl-cms-content"
 
+type HealthStatusRequest = {
+  function: string
+  route: string
+  status: "ok" | "error"
+  message: string
+}
+
 type HealthStatusRequestBody = {
   version: string
-  requests: {
-    [key: string]: {
-      status: "ok" | "error"
-      message: string
-    }
-  }
+  requests: HealthStatusRequest[]
 }
 
 async function getHealthStatus() {
   const requestBody: HealthStatusRequestBody = {
     version: "",
-    requests: {},
+    requests: [],
   }
 
   try {
@@ -35,22 +37,30 @@ async function getHealthStatus() {
       type: "page",
     })
 
-    if (!isEmpty(frontpageData)) {
-      requestBody.requests.frontpage = {
+    const { ...data } = frontpageData
+
+    if (!isEmpty(data)) {
+      requestBody.requests.push({
+        function: "loadPageData",
+        route: goConfig("routes.frontpage"),
         status: "ok",
         message: "Frontpage data loaded successfully",
-      }
+      })
     } else {
-      requestBody.requests.frontpage = {
+      requestBody.requests.push({
+        function: "loadPageData",
+        route: goConfig("routes.frontpage"),
         status: "error",
         message: `Frontpage data is empty`,
-      }
+      })
     }
   } catch (error) {
-    requestBody.requests.frontpage = {
+    requestBody.requests.push({
+      function: "loadPageData",
+      route: goConfig("routes.frontpage"),
       status: "error",
       message: `Error loading frontpage data: ${error instanceof Error ? error.message : "Unknown error"}`,
-    }
+    })
   }
 
   return NextResponse.json(requestBody, { status: 200 })


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-299

#### Description

This PR adds a new Next.js server route that returns the current release version and a requests array. The array includes endpoints tied to critical application functionality, intended for periodic monitoring. Additional requests will be added in the future.