### PR TITLE
feat: implement material type redirection when no type is present in …

### DIFF
--- a/components/pages/workPageLayout/WorkPageLayout.tsx
+++ b/components/pages/workPageLayout/WorkPageLayout.tsx
@@ -75,7 +75,7 @@ function WorkPageLayout({ workId }: { workId: string }) {
     })
 
     setSelectedManifestation(selectedManifestation)
-  }, [searchParams])
+  }, [searchParams, manifestations])
 
   if (isLoading && !data) {
     return (

--- a/components/pages/workPageLayout/helper.ts
+++ b/components/pages/workPageLayout/helper.ts
@@ -20,6 +20,25 @@ export const getManifestationMaterialType = (
 const allowedMaterialTypes = ["BOOKS", "EBOOKS", "AUDIO_BOOKS", "PODCASTS"]
 const allowedPhysicalMaterialTypes = ["BOOKS"]
 
+export const hasManifestationAllowedMaterialTypes = (
+  manifestation: ManifestationWorkPageFragment
+) => {
+  // if the manifestation is physical, we only want to include it if it's a an allowed material physical type
+  if (manifestation.accessTypes[0].code === "PHYSICAL") {
+    return allowedPhysicalMaterialTypes.includes(
+      manifestation.materialTypes[0]?.materialTypeGeneral.code
+    )
+  }
+
+  // if the manifestation is online, we want to include it if it has an allowed online material type
+  if (manifestation.accessTypes[0].code === "ONLINE") {
+    const matchingMaterialType = manifestation.materialTypes.find(type =>
+      allowedMaterialTypes.includes(type.materialTypeGeneral.code)
+    )
+    return !!matchingMaterialType
+  }
+}
+
 // filter out unallowed material types from manifestations
 export const filterMaterialTypes = (manifestations: ManifestationWorkPageFragment[]) => {
   const filteredManifestationsMaterialTypes = manifestations.map(manifestation => {
@@ -40,19 +59,8 @@ export const filterManifestationsByMaterialType = (
   manifestations: ManifestationWorkPageFragment[]
 ) => {
   return filter(manifestations, manifestation => {
-    // if the manifestation is physical, we only want to include it if it's a an allowed material physical type
-    if (manifestation.accessTypes[0].code === "PHYSICAL") {
-      return allowedPhysicalMaterialTypes.includes(
-        manifestation.materialTypes[0]?.materialTypeGeneral.code
-      )
-    }
-    if (manifestation.accessTypes[0].code === "ONLINE") {
-      const matchinMaterialType = manifestation.materialTypes.find(type =>
-        allowedMaterialTypes.includes(type.materialTypeGeneral.code)
-      )
-      return !!matchinMaterialType
-    }
-    return false
+    const isAllowedMaterialType = hasManifestationAllowedMaterialTypes(manifestation)
+    return isAllowedMaterialType || false
   })
 }
 

--- a/components/pages/workPageLayout/helper.ts
+++ b/components/pages/workPageLayout/helper.ts
@@ -37,6 +37,8 @@ export const hasManifestationAllowedMaterialTypes = (
     )
     return !!matchingMaterialType
   }
+
+  return false
 }
 
 // filter out unallowed material types from manifestations
@@ -60,7 +62,7 @@ export const filterManifestationsByMaterialType = (
 ) => {
   return filter(manifestations, manifestation => {
     const isAllowedMaterialType = hasManifestationAllowedMaterialTypes(manifestation)
-    return isAllowedMaterialType || false
+    return isAllowedMaterialType
   })
 }
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-310

#### Description

The new Go solution must be able to handle redirects from the old ereolengo.dk site to the new one via https://reload.github.io/ereolen-go/

Material pages in the old solution do not have a type specified in the URL:
https://ereolengo.dk/ting/object/870970-basis%3A141030485?u_navigatedby=Nye%20eb%C3%B8ger

The new Go solution expects a type parameter in order to display a page:
https://go.bibliotek.kk.dk/work/work-of%3A870970-basis%3A27866360?type=AUDIO_BOOKS

To resolve this issue, the following logic has been implemented:
1. If a user navigates to a material page in Go without a type, we will set one via code.
2. The type to be set is the bestRepresentation manifestation type.
3. If bestRepresentation is not an allowed manifestation vi will fallback to the first allowed manifestation in manifestations list