### PR TITLE
Example of setting the go session cookie in cypress

### DIFF
--- a/cypress/e2e/frontpage.cy.ts
+++ b/cypress/e2e/frontpage.cy.ts
@@ -95,9 +95,7 @@ describe("Front Page Tests", () => {
   })
 
   it.only("Should be able to navigate to the user profile page (/user/profile) if a session cookie has been set", () => {
-    cy.getMockedGoSessionCookieValue({ type: "unilogin" }).then(encodedSession => {
-      cy.setCookie("go-session", encodedSession)
-      cy.visit("/user/profile")
-    })
+    cy.createGoSession({ type: "unilogin" })
+    cy.visit("/user/profile")
   })
 })

--- a/cypress/e2e/frontpage.cy.ts
+++ b/cypress/e2e/frontpage.cy.ts
@@ -93,4 +93,11 @@ describe("Front Page Tests", () => {
     cy.dataCy("search-input").should("exist").focus().type("harry potter{enter}")
     cy.url().should("include", "/search")
   })
+
+  it.only("Should be able to navigate to the user profile page (/user/profile) if a session cookie has been set", () => {
+    cy.getMockedGoSessionCookieValue({ type: "unilogin" }).then(encodedSession => {
+      cy.setCookie("go-session", encodedSession)
+      cy.visit("/user/profile")
+    })
+  })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -120,14 +120,17 @@ declare global {
       resetServerMocks(): void
 
       /**
-       * Gets the value of a mocked the go-session cookie
+       * Creates a new GO session of the specified type.
+       * This custom Cypress command initializes a session for testing purposes,
+       * allowing you to simulate different user session types within your tests.
        *
-       * @param type - The session type to retrieve ("unilogin", "adgangsplatformen", etc.)
-       * @example  cy.task("getMockedGoSessionCookieValue", { type: "unilogin" }).then((encodedSession: string) => {
-       *   // Do something with the encoded session
-       * })
+       * @param params - An object containing the session details.
+       * @param params.type - The type of session to create (e.g., "unilogin", "adgangsplatformen", etc.).
+       * @returns A Cypress Chainable that resolves when the session has been created.
+       * @example
+       * cy.createGoSession({ type: "unilogin" })
        */
-      getMockedGoSessionCookieValue({ type }: { type: TSessionType }): Chainable<string>
+      createGoSession({ type }: { type: TSessionType }): Chainable<void>
 
       /**
        * Checks if the current viewport is mobile
@@ -228,6 +231,8 @@ Cypress.Commands.add("setViewport", (viewport: ViewportType) => {
   cy.viewport(viewports[viewport].width, viewports[viewport].height)
 })
 
-Cypress.Commands.add("getMockedGoSessionCookieValue", ({ type }: { type: TSessionType }) => {
-  return cy.task("getMockedGoSessionCookieValue", { type })
+Cypress.Commands.add("createGoSession", ({ type }: { type: TSessionType }) => {
+  cy.task("getMockedGoSessionCookieValue", { type }).then(encodedSession => {
+    cy.setCookie("go-session", encodedSession as string)
+  })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import { Cover } from "@/lib/rest/cover-service-api/generated/model"
+import { TSessionType } from "@/lib/types/session"
 
 import { CyKey, ViewportType, viewports } from "./constants"
 import { Operations, hasOperationName } from "./utils"
@@ -119,6 +120,16 @@ declare global {
       resetServerMocks(): void
 
       /**
+       * Gets the value of a mocked the go-session cookie
+       *
+       * @param type - The session type to retrieve ("unilogin", "adgangsplatformen", etc.)
+       * @example  cy.task("getMockedGoSessionCookieValue", { type: "unilogin" }).then((encodedSession: string) => {
+       *   // Do something with the encoded session
+       * })
+       */
+      getMockedGoSessionCookieValue({ type }: { type: TSessionType }): Chainable<string>
+
+      /**
        * Checks if the current viewport is mobile
        * @example cy.isViewport("mobile")
        */
@@ -215,4 +226,8 @@ Cypress.Commands.add("isViewport", (viewport: ViewportType) => {
 
 Cypress.Commands.add("setViewport", (viewport: ViewportType) => {
   cy.viewport(viewports[viewport].width, viewports[viewport].height)
+})
+
+Cypress.Commands.add("getMockedGoSessionCookieValue", ({ type }: { type: TSessionType }) => {
+  return cy.task("getMockedGoSessionCookieValue", { type })
 })


### PR DESCRIPTION
This is how we should be able to fake a logged in session in Cypress