### PR TITLE
fix: add error logging for missing institution_ids in introspection r…

### DIFF
--- a/app/(routes)/auth/callback/unilogin/route.ts
+++ b/app/(routes)/auth/callback/unilogin/route.ts
@@ -89,6 +89,15 @@ export async function GET(request: NextRequest) {
       tokenSet.access_token!
     )) as TIntrospectionResponse
 
+    if (!introspectResponse.institution_ids) {
+      console.error(
+        "No institution_ids or undefined institution_ids value found on introspection response",
+        {
+          uniid: introspectResponse.uniid,
+        }
+      )
+    }
+
     const introspect = schemas.introspect.parse(introspectResponse)
 
     const claims = tokenSetResponse.claims()! as TClaims


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-367

#### Description

To improve error traceability during Unilogin authentication failures with missing institution_ids, we log the user's uniid alongside error information, enabling us to identify specific users experiencing login issues.