### PR TITLE
Remove pcke code verifier from session on non auth routes

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -70,6 +70,8 @@ vi.mock("@/lib/session/session", async importOriginal => {
     getDplCmsSessionCookie: vi.fn(),
     getSession: vi.fn(),
     saveAdgangsplatformenSession: vi.fn(),
+    removePCKECodeVerifierFromSession: vi.fn(),
+    sessionHasPKCECodeVerifier: vi.fn(),
   }
 })
 
@@ -390,5 +392,63 @@ describe("Middleware", () => {
     await middleware(getNextRequestWithLibraryTokenCookie())
 
     expect(destroySessionSpy).toHaveResolvedTimes(1)
+  })
+
+  it("removes PKCE code verifier from session if it exists", async () => {
+    vi.spyOn(headersFunctions, "cookies").mockResolvedValue(
+      Promise.resolve({
+        getAll: vi.fn(() => []),
+      })
+    )
+
+    // Create a session with a code_verifier
+    const sessionWithCodeVerifier = {
+      ...sessions.anonymousSession,
+      code_verifier: "test-pkce-code-verifier",
+      save: vi.fn(),
+    }
+
+    vi.spyOn(sessionFunctions, "getSession").mockResolvedValue(
+      Promise.resolve(sessionWithCodeVerifier)
+    )
+
+    const removePCKECodeVerifierSpy = vi.spyOn(
+      sessionFunctions,
+      "removePCKECodeVerifierFromSession"
+    )
+
+    await middleware(getNextRequestWithLibraryTokenCookie())
+
+    // Verify that the function was called with the session
+    expect(removePCKECodeVerifierSpy).toHaveBeenCalledTimes(1)
+    expect(removePCKECodeVerifierSpy).toHaveBeenCalledWith(sessionWithCodeVerifier)
+  })
+
+  it("does not attempt to remove PKCE code verifier if it doesn't exist in session", async () => {
+    vi.spyOn(headersFunctions, "cookies").mockResolvedValue(
+      Promise.resolve({
+        getAll: vi.fn(() => []),
+      })
+    )
+
+    // Create a session without a code_verifier
+    const sessionWithoutCodeVerifier = {
+      ...sessions.anonymousSession,
+      save: vi.fn(),
+    }
+
+    vi.spyOn(sessionFunctions, "getSession").mockResolvedValue(
+      Promise.resolve(sessionWithoutCodeVerifier)
+    )
+
+    const removePCKECodeVerifierSpy = vi.spyOn(
+      sessionFunctions,
+      "removePCKECodeVerifierFromSession"
+    )
+
+    await middleware(getNextRequestWithLibraryTokenCookie())
+
+    // Verify that the removal function was NOT called since there's no code_verifier
+    expect(removePCKECodeVerifierSpy).toHaveBeenCalledTimes(0)
   })
 })

--- a/lib/session/session.ts
+++ b/lib/session/session.ts
@@ -295,11 +295,11 @@ export const redirectToFrontPageAndReloadSession = async () => {
   return NextResponse.redirect(`${appUrl.toString()}?reload-session=true`)
 }
 
-export const removePCKECodeVerifierFromSessionIfItExists = async (
-  session: IronSession<TSessionData>
-) => {
-  if (session.code_verifier) {
-    delete session.code_verifier
-    await session.save()
-  }
+export const sessionHasPKCECodeVerifier = (session: IronSession<TSessionData>) => {
+  return !!session.code_verifier
+}
+
+export const removePCKECodeVerifierFromSession = async (session: IronSession<TSessionData>) => {
+  delete session.code_verifier
+  await session.save()
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,8 +14,9 @@ import {
   destroySession,
   getDplCmsSessionCookie,
   getSession,
-  removePCKECodeVerifierFromSessionIfItExists,
+  removePCKECodeVerifierFromSession,
   saveAdgangsplatformenSession,
+  sessionHasPKCECodeVerifier,
   uniloginAccessTokenHasExpired,
   uniloginAccessTokenShouldBeRefreshed,
 } from "./lib/session/session"
@@ -38,10 +39,12 @@ export async function middleware(request: NextRequest) {
 
   const session = await getSession()
 
-  // Since we  do not need the PKCE code verifier on non-auth routes,
+  // Since we do not need the PKCE code verifier on non-auth routes,
   // we will remove it from the session if it exists.
   // It is safe because the middleware only runs on non-auth routes.
-  await removePCKECodeVerifierFromSessionIfItExists(session)
+  if (sessionHasPKCECodeVerifier(session)) {
+    await removePCKECodeVerifierFromSession(session)
+  }
 
   if (protectedPages.includes(currentPath)) {
     // If the user is anonymous, we will redirect to the front page.


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-366

#### Description

This should not be necessary since we anyways create a new one when logging in.
But just to be sure we delete it since there is no use for it on non auth routes.

