### PR TITLE
Ddfsal 401 fjerne env production fil

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -11,6 +11,5 @@ UNILOGIN_WELLKNOWN_URL=https://broker.unilogin.dk/auth/realms/broker/.well-known
 # UNILOGIN AND PUBLIZON
 UNILOGIN_WELLKNOWN_URL=https://broker.unilogin.dk/auth/realms/broker/.well-known/openid-configuration
 UNLILOGIN_PUBHUB_CLIENT_ID=EE939D96-702D-4BEE-AEB7-517B8BA18B15
-UNLILOGIN_PUBHUB_RETAILER_ID=810
 UNILOGIN_CLIENT_ID=https://ereolengo.dk/
 NEXT_PUBLIC_PUBHUB_BASE_URL=https://pubhub-openplatform.dbc.dk

--- a/lib/helpers/publizon.ts
+++ b/lib/helpers/publizon.ts
@@ -1,17 +1,13 @@
 import { md5 } from "js-md5"
 
-import { getDplCmsPrivateConfig } from "../config/dpl-cms/dplCmsConfig"
 import { getServerEnv } from "../config/env"
 
 export const getPublizonServiceParameters = async () => {
-  const {
-    unilogin: { pubHubRetailerKeyCode },
-  } = await getDplCmsPrivateConfig()
   return {
     clientid: getServerEnv("UNLILOGIN_PUBHUB_CLIENT_ID") ?? "",
     retailerid: getServerEnv("UNLILOGIN_PUBHUB_RETAILER_ID") ?? "",
     // The  Publizon services expect the retailerkeycode to be an MD5 hash
     // of the actual key code.
-    retailerkeycode: md5(pubHubRetailerKeyCode ?? ""),
+    retailerkeycode: md5(getServerEnv("UNLILOGIN_PUBHUB_RETAILER_KEY_CODE") ?? ""),
   }
 }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-401

#### Description

- Removed fallback variables from the .env.production
- Changed `UNLILOGIN_PUBHUB_RETAILER_KEY_CODE` to be loaded from env variables instead of dpl-cms