### PR TITLE
DDFSAL-439: Added Cookie Information banner

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -64,7 +64,9 @@ export default function Layout({
   return (
     <html lang="da">
       <body className={`${GTFlexa.variable} duration-dark-mode antialiased transition-all`}>
-        <CookieInformation />
+        <Suspense>
+          <CookieInformation />
+        </Suspense>
         <GridHelper hideInProduction />
         <Suspense>
           <RootLayout>

--- a/lib/services/cookieInformation.tsx
+++ b/lib/services/cookieInformation.tsx
@@ -1,6 +1,15 @@
+import { headers } from "next/headers"
 import Script from "next/script"
 
-export function CookieInformation() {
+export async function CookieInformation() {
+  const headersList = await headers()
+  const host = headersList.get("host") || ""
+
+  // Temporarily only render on go.delingstjenesten.dk
+  if (host !== "go.delingstjenesten.dk") {
+    return null
+  }
+
   return (
     <Script
       id="CookieConsent"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-439

#### Description
This PR introduces the Cookie Information banner script

#### Screenshot of the result
<img width="2560" height="1272" alt="image" src="https://github.com/user-attachments/assets/9bae4155-6dee-4c87-a89f-ae8263cc987c" />


#### Additional comments or questions
As a start, we only want to render the banner on go.delingstjenesten.dk, for the team to make sure everything works as expected.
