### PR TITLE
DDFSAL-466-default-to-ebook

### DIFF
--- a/components/pages/searchPageLayout/SearchResults.tsx
+++ b/components/pages/searchPageLayout/SearchResults.tsx
@@ -13,7 +13,7 @@ import {
   filterManifestationsByEdition,
   filterManifestationsByMaterialType,
   filterMaterialTypes,
-  getBestRepresentationOrFallbackManifestation,
+  getEbookManifestationOrFallbackManifestation,
   sortManifestationsBySortPriority,
 } from "../workPageLayout/helper"
 
@@ -30,17 +30,17 @@ const SearchResults = ({ works }: SearchResultProps) => {
             filterManifestationsByMaterialType(filterMaterialTypes(work.manifestations.all))
           )
         )
-        const bestRepresentation = getBestRepresentationOrFallbackManifestation(
+        const manifestation = getEbookManifestationOrFallbackManifestation(
           work.manifestations.bestRepresentation,
           manifestations
         )
 
         const title = work.titles.full[0]
-        const url = bestRepresentation
+        const url = manifestation
           ? resolveUrl({
               routeParams: { work: "work", wid: work.workId },
               queryParams: {
-                type: bestRepresentation.materialTypes[0].materialTypeGeneral.code,
+                type: manifestation.materialTypes[0].materialTypeGeneral.code,
               },
             })
           : ""
@@ -53,11 +53,11 @@ const SearchResults = ({ works }: SearchResultProps) => {
               className="focus-visible"
               href={url}>
               <WorkCardWithCaption title={title} creators={work.creators || []}>
-                {bestRepresentation ? (
+                {manifestation ? (
                   <WorkCard
                     workId={work.workId}
                     title={title}
-                    bestRepresentation={bestRepresentation}
+                    bestRepresentation={manifestation}
                     manifestations={manifestations}
                     isWithTilt
                   />

--- a/components/pages/workPageLayout/WorkPageLayout.tsx
+++ b/components/pages/workPageLayout/WorkPageLayout.tsx
@@ -19,7 +19,7 @@ import {
   filterManifestationsByEdition,
   filterManifestationsByMaterialType,
   filterMaterialTypes,
-  getBestRepresentationOrFallbackManifestation,
+  getEbookManifestationOrFallbackManifestation,
 } from "./helper"
 
 function WorkPageLayout({ workId }: { workId: string }) {
@@ -52,8 +52,8 @@ function WorkPageLayout({ workId }: { workId: string }) {
     const searchParamsMaterialType = searchParams.get("type")
 
     if (!searchParamsMaterialType && bestRepresentation) {
-      // If no material type is specified is url params, redirect the bestRepresentation manifestation if available or a fallback manifestation
-      const manifestation = getBestRepresentationOrFallbackManifestation(
+      // If no material type is specified is url params, redirect to the ebook manifestation if available or a fallback manifestation
+      const manifestation = getEbookManifestationOrFallbackManifestation(
         bestRepresentation,
         manifestations
       )
@@ -74,6 +74,7 @@ function WorkPageLayout({ workId }: { workId: string }) {
     }) as ManifestationWorkPageFragment
 
     setSelectedManifestation(selectedManifestation)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, manifestations])
 
   if (isLoading && !data) {

--- a/components/pages/workPageLayout/helper.ts
+++ b/components/pages/workPageLayout/helper.ts
@@ -120,11 +120,11 @@ export const getEbookManifestationOrFallbackManifestation = (
   const ebookManifestation = manifestations.find(manifestation =>
     isManifestationEbook(manifestation)
   )
-  
+
   if (ebookManifestation) {
     return ebookManifestation
   }
-  
+
   return getBestRepresentationOrFallbackManifestation(bestRepresentation, manifestations)
 }
 

--- a/components/paragraphs/MaterialSlider/MaterialSlider.tsx
+++ b/components/paragraphs/MaterialSlider/MaterialSlider.tsx
@@ -10,7 +10,7 @@ import {
   filterManifestationsByEdition,
   filterManifestationsByMaterialType,
   filterMaterialTypes,
-  getBestRepresentationOrFallbackManifestation,
+  getEbookManifestationOrFallbackManifestation,
   sortManifestationsBySortPriority,
 } from "@/components/pages/workPageLayout/helper"
 import { WheelControls, defaultSliderOptions } from "@/components/paragraphs/MaterialSlider/helper"
@@ -104,17 +104,17 @@ const MaterialSlider = ({ works, title }: MaterialSliderProps) => {
                     )
                   )
 
-                  const bestRepresentation = getBestRepresentationOrFallbackManifestation(
+                  const manifestation = getEbookManifestationOrFallbackManifestation(
                     work.manifestations.bestRepresentation,
                     manifestations
                   )
 
                   const title = work.titles.full[0]
-                  const url = bestRepresentation
+                  const url = manifestation
                     ? resolveUrl({
                         routeParams: { work: "work", wid: work.workId },
                         queryParams: {
-                          type: bestRepresentation.materialTypes[0].materialTypeGeneral.code,
+                          type: manifestation.materialTypes[0].materialTypeGeneral.code,
                         },
                       })
                     : ""
@@ -127,12 +127,12 @@ const MaterialSlider = ({ works, title }: MaterialSliderProps) => {
                       className="keen-slider__slide focus-visible outline-accent-foreground focus:outline-offset-2"
                       href={url || ""}>
                       <WorkCardWithCaption title={title} creators={work.creators || []}>
-                        {bestRepresentation ? (
+                        {manifestation ? (
                           <WorkCard
                             className="dark:bg-background-overlay !dark:bg-background"
                             workId={work.workId}
                             title={title}
-                            bestRepresentation={bestRepresentation}
+                            bestRepresentation={manifestation}
                             manifestations={manifestations}
                             isWithTilt={true}
                           />

--- a/components/shared/workCard/WorkCardStackedWithCaption.tsx
+++ b/components/shared/workCard/WorkCardStackedWithCaption.tsx
@@ -5,7 +5,7 @@ import {
   filterManifestationsByEdition,
   filterManifestationsByMaterialType,
   filterMaterialTypes,
-  getBestRepresentationOrFallbackManifestation,
+  getEbookManifestationOrFallbackManifestation,
   sortManifestationsBySortPriority,
 } from "@/components/pages/workPageLayout/helper"
 import WorkCard, { WorkCardEmpty } from "@/components/shared/workCard/WorkCard"
@@ -42,17 +42,17 @@ const WorkCardStackedWithCaption = ({
     )
   )
 
-  const bestRepresentation = getBestRepresentationOrFallbackManifestation(
+  const manifestation = getEbookManifestationOrFallbackManifestation(
     currentWork.manifestations.bestRepresentation,
     manifestations
   )
 
   const title = currentWork.titles.full[0]
-  const url = bestRepresentation
+  const url = manifestation
     ? resolveUrl({
         routeParams: { work: "work", wid: currentWork.workId },
         queryParams: {
-          type: bestRepresentation.materialTypes[0].materialTypeGeneral.code,
+          type: manifestation.materialTypes[0].materialTypeGeneral.code,
         },
       })
     : ""
@@ -85,12 +85,12 @@ const WorkCardStackedWithCaption = ({
           creators={currentWork.creators || []}
           title={title}
           className="pointer-events-auto relative h-auto overflow-visible opacity-100">
-          {bestRepresentation ? (
+          {manifestation ? (
             <WorkCard
               className={cn("bg-background dark:bg-background-overlay-solid shadow-stacked-card")}
               workId={currentWork.workId}
               title={title}
-              bestRepresentation={bestRepresentation}
+              bestRepresentation={manifestation}
               manifestations={manifestations}
               isWithTilt
             />


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-466

#### Description

Two main commits:

1. Added function to return the ebook manifestation on a work if it present, or fallback to existing logic
◦  Created a new helper function getEbookManifestationOrFallbackManifestation in helper.ts
◦  This function searches for an ebook manifestation and returns it if found, otherwise falls back to the previous logic

2. Use ebook as priority manifestation throughout application
◦  Replaced calls to getBestRepresentationOrFallbackManifestation with the new getEbookManifestationOrFallbackManifestation function across five component files:
▪  SearchResults
▪  WorkPageLayout
▪  MaterialSlider
▪  WorkCardStackedWithCaption
◦  This ensures eBooks are prioritized as the default manifestation wherever works are displayed