### PR TITLE
fix: cover sizing in GO material slider

### DIFF
--- a/components/pages/workPageLayout/WorkPageHeader.tsx
+++ b/components/pages/workPageLayout/WorkPageHeader.tsx
@@ -73,6 +73,8 @@ const WorkPageHeader = ({ manifestations, work, selectedManifestation }: WorkPag
   const selectedManifestationMaterialTypeCode =
     selectedManifestation?.materialTypes[0].materialTypeGeneral.code
 
+  const manifestationKey = selectedManifestation?.pid
+
   const isSelectedManifestationPodcast =
     selectedManifestationMaterialTypeCode === "PODCASTS" || false
 
@@ -91,11 +93,17 @@ const WorkPageHeader = ({ manifestations, work, selectedManifestation }: WorkPag
         transition={{ duration: 0.5 }}
         exit={{ opacity: 0 }}>
         <div className="col-span-4 h-auto lg:order-2">
-          <div
+          <motion.div
+            key={manifestationKey}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.3 }}
             className="rounded-base flex aspect-1/1 h-auto w-full flex-col items-center
               justify-center lg:aspect-4/5">
-            {covers && <CoverPicture alt="Forsidebillede på værket" covers={covers} />}
-          </div>
+            {covers && (
+              <CoverPicture withTilt={true} alt="Forsidebillede på værket" covers={covers} />
+            )}
+          </motion.div>
           {slideSelectOptions && (
             <div className="flex w-full justify-center pt-12">
               <SlideSelect

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -129,7 +129,7 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
           <Icon
             name="question-mark"
             className="text-foreground h-[50px] opacity-20 lg:h-[100px]"
-            aria-label="Question mark icon"
+            aria-label="Spørgsmålstegn ikon"
           />
           <p className="text-typo-caption text-center opacity-55">Billede kunne ikke vises</p>
         </motion.div>

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { motion } from "framer-motion"
 import React, { useEffect, useRef, useState } from "react"
 import Tilt from "react-parallax-tilt"
@@ -79,6 +81,7 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
     <div className={cn("flex h-full w-full items-center", className)} ref={ref}>
       {!imageError && covers.thumbnail ? (
         <CoverPictureTiltWrapper
+          key={covers.thumbnail}
           withTilt={withTilt}
           className={"relative m-auto"}
           style={coverWrapperStyle}>

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -128,7 +128,7 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
             className="text-foreground h-[50px] opacity-20 lg:h-[100px]"
             aria-label="Question mark icon"
           />
-          <p className="text-typo-caption text-center opacity-55">Image could not be displayed</p>
+          <p className="text-typo-caption text-center opacity-55">Billede kunne ikke vises</p>
         </motion.div>
       )}
     </div>

--- a/components/shared/coverPicture/CoverPicture.tsx
+++ b/components/shared/coverPicture/CoverPicture.tsx
@@ -1,4 +1,3 @@
-import { useWindowSize } from "@uidotdev/usehooks"
 import { motion } from "framer-motion"
 import React, { useEffect, useRef, useState } from "react"
 import Tilt from "react-parallax-tilt"
@@ -14,30 +13,67 @@ type CoverPictureProps = {
   withTilt?: boolean
 }
 export const CoverPicture = ({ covers, alt, withTilt = false, className }: CoverPictureProps) => {
-  const size = useWindowSize()
   const imageAspectRatio = (covers.large?.width ?? 0) / (covers.large?.height ?? 0)
 
-  // get the container height
   const ref = useRef<HTMLDivElement>(null)
-  const containerHeight = ref.current?.getBoundingClientRect().height || 0
-  const containerWidth = ref.current?.getBoundingClientRect().width || 0
 
-  // calculate container aspect ratio
-  const containerAspectRatio = containerWidth / containerHeight
+  const [containerSize, setContainerSize] = useState<{ width: number; height: number } | null>(null)
 
-  // calculate the max width using image aspect ratio and container width
-  const imageWidthByContainerHeight = imageAspectRatio * containerHeight
-  const imageHeightByContainerWidth = containerWidth / imageAspectRatio
+  // Keep container size in sync with layout changes using ResizeObserver so we also react
+  // when Keen slider changes slide width (without requiring a window resize).
+  useEffect(() => {
+    if (!ref.current) return
 
-  useEffect(() => {}, [size.width])
+    const el = ref.current
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0]
+      if (!entry) return
+
+      const { width, height } = entry.contentRect
+      if (!width || !height) return
+
+      setContainerSize(prev => {
+        if (prev && prev.width === width && prev.height === height) return prev
+        return { width, height }
+      })
+    })
+
+    observer.observe(el)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  const containerHeight = containerSize?.height ?? 0
+  const containerWidth = containerSize?.width ?? 0
+
+  // Fallback to image aspect ratio if we don't yet know the container size to avoid NaN calculations
+  const hasContainerSize = containerHeight > 0 && containerWidth > 0 && imageAspectRatio > 0
+
+  // Calculate a width/height that fits INSIDE the container ("object-fit: contain" behavior)
+  let coverWidth = 0
+  let coverHeight = 0
+
+  if (hasContainerSize) {
+    // Start by filling the container width
+    coverWidth = containerWidth
+    coverHeight = coverWidth / imageAspectRatio
+
+    // If the result becomes taller than the container, constrain by height instead
+    if (coverHeight > containerHeight) {
+      coverHeight = containerHeight
+      coverWidth = coverHeight * imageAspectRatio
+    }
+  }
+
   const [imageLoaded, setImageLoaded] = useState(false)
   const [imageError, setImageError] = useState(false)
 
-  // adjust the padding top based on the image aspect ratio and the container width
-  const paddingTop =
-    containerHeight > imageHeightByContainerWidth
-      ? `${100 / imageAspectRatio}%`
-      : `${100 / containerAspectRatio}%`
+  // Use a style that either matches the calculated size or falls back to 100%
+  const coverWrapperStyle: React.CSSProperties = hasContainerSize
+    ? { width: `${coverWidth}px`, height: `${coverHeight}px` }
+    : { width: "100%", height: "100%" }
 
   return (
     <div className={cn("flex h-full w-full items-center", className)} ref={ref}>
@@ -45,7 +81,7 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
         <CoverPictureTiltWrapper
           withTilt={withTilt}
           className={"relative m-auto"}
-          style={{ paddingTop, width: `${imageWidthByContainerHeight}px` }}>
+          style={coverWrapperStyle}>
           {covers.thumbnail && (
             // eslint-disable-next-line @next/next/no-img-element
             <img
@@ -90,9 +126,9 @@ export const CoverPicture = ({ covers, alt, withTilt = false, className }: Cover
           <Icon
             name="question-mark"
             className="text-foreground h-[50px] opacity-20 lg:h-[100px]"
-            aria-label="Spørgsmålstegn ikon"
+            aria-label="Question mark icon"
           />
-          <p className="text-typo-caption text-center opacity-55">Billede kunne ikke vises</p>
+          <p className="text-typo-caption text-center opacity-55">Image could not be displayed</p>
         </motion.div>
       )}
     </div>

--- a/components/shared/workCard/WorkCardStackedWithCaption.tsx
+++ b/components/shared/workCard/WorkCardStackedWithCaption.tsx
@@ -92,7 +92,6 @@ const WorkCardStackedWithCaption = ({
               title={title}
               bestRepresentation={manifestation}
               manifestations={manifestations}
-              isWithTilt
             />
           ) : (
             <WorkCardEmpty


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDF-30

#### Description

•  Fixed the issue where work covers in the GO material slider sometimes rendered very small on initial load and only resized correctly after a window resize.  
•  Switched CoverPicture from using window width–based measurements to a ResizeObserver that tracks the actual slide/container size, so cover sizing updates whenever Keen slider changes slide width.  
•  Implemented “fit inside container” logic for covers (equivalent to object-fit: contain): covers keep their aspect ratio, never overflow the card, and always use the maximum possible size within the container.  
