### PR TITLE
Use go profile with FBI

### DIFF
--- a/cypress/factories/dpl-cms/getDplCmsPublicConfiguration.ts
+++ b/cypress/factories/dpl-cms/getDplCmsPublicConfiguration.ts
@@ -10,9 +10,6 @@ export default Factory.define<GetDplCmsPublicConfigurationQuery>(() => {
     go: defaultGoResponse.build(),
     goConfiguration: {
       public: {
-        searchProfiles: {
-          local: "next",
-        },
         loginUrls: {
           adgangsplatformen: "/mocked/login",
         },

--- a/lib/config/dpl-cms/configSchemas.ts
+++ b/lib/config/dpl-cms/configSchemas.ts
@@ -1,9 +1,6 @@
 import { z } from "zod"
 
 export const publicConfigSchema = z.object({
-  searchProfiles: z.object({
-    local: z.string().nullable(),
-  }),
   loginUrls: z.object({
     adgangsplatformen: z.string().nullable(),
   }),

--- a/lib/config/dpl-cms/dplCmsConfig.ts
+++ b/lib/config/dpl-cms/dplCmsConfig.ts
@@ -80,9 +80,6 @@ const getDplCmsPublicConfigData = async () => {
   } catch {
     console.error("Failed to parse DPL CMS public config")
     return {
-      searchProfiles: {
-        local: null,
-      },
       loginUrls: {
         adgangsplatformen: null,
       },

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -96,7 +96,7 @@ function validateEnv<T extends z.ZodSchema>(schema: T): z.infer<T> {
   const message = "Environment variables doesn't match type signature"
   console.error("\n\n\x1b[41m%s\x1b[0m", message)
   console.info("Type mismatch: ", result.error.toString())
-  throw "Make sure you have all the required environment variables set"
+  throw new Error("Make sure you have all the required environment variables set")
 }
 
 function validateUrl(url: string) {
@@ -108,9 +108,14 @@ function validateUrl(url: string) {
   }
 }
 
-// Validating runtime on start-up for browser or server side
-if (typeof window !== "undefined") {
-  validateEnv(EnvSchema)
-} else {
-  validateEnv(EnvServerSchema)
+// If SKIP_ENV_VALIDATION is set to "1", we skip env validation.
+const shouldValidateEnv = process.env?.SKIP_ENV_VALIDATION !== "1"
+if (shouldValidateEnv) {
+  if (typeof window !== "undefined") {
+    // Validating envs for client-side
+    validateEnv(EnvSchema)
+  } else {
+    // Validating envs for server-side
+    validateEnv(EnvServerSchema)
+  }
 }

--- a/lib/config/resolvers/services.ts
+++ b/lib/config/resolvers/services.ts
@@ -1,7 +1,7 @@
 const services = {
   "services.ap-services": {
     fbi: {
-      url: "https://fbi-api.dbc.dk/{search_profile_placeholder}/graphql",
+      url: "https://fbi-api.dbc.dk/fbscms-go/graphql",
       useLibraryTokenAlways: false,
     },
     "pubhub-adapter": { url: "https://pubhub-openplatform.dbc.dk", useLibraryTokenAlways: false },

--- a/lib/config/resolvers/services.ts
+++ b/lib/config/resolvers/services.ts
@@ -1,7 +1,7 @@
 const services = {
   "services.ap-services": {
     fbi: {
-      url: "https://fbi-api.dbc.dk/fbscms-go/graphql",
+      url: "https://fbi-api.dbc.dk/fbcms-go/graphql",
       useLibraryTokenAlways: false,
     },
     "pubhub-adapter": { url: "https://pubhub-openplatform.dbc.dk", useLibraryTokenAlways: false },

--- a/lib/graphql/generated/dpl-cms/graphql.ts
+++ b/lib/graphql/generated/dpl-cms/graphql.ts
@@ -232,7 +232,7 @@ export type Language = {
   direction?: Maybe<Scalars['String']['output']>;
   /** Sprogkoden. */
   id?: Maybe<Scalars['ID']['output']>;
-  /** Sprogets navn. */
+  /** Navnet på sproget. */
   name?: Maybe<Scalars['String']['output']>;
 };
 
@@ -358,6 +358,7 @@ export type MediaVideo = MediaInterface & {
   path?: Maybe<Scalars['String']['output']>;
   /** Published */
   status: Scalars['Boolean']['output'];
+  thumbnail: Scalars['String']['output'];
 };
 
 /** Entity type media. */
@@ -379,6 +380,7 @@ export type MediaVideotool = MediaInterface & {
   path?: Maybe<Scalars['String']['output']>;
   /** Published */
   status: Scalars['Boolean']['output'];
+  thumbnail: Scalars['String']['output'];
 };
 
 /** The schema's entry-point for mutations. */
@@ -768,6 +770,7 @@ export type ParagraphCardGridManual = ParagraphInterface & {
   created: DateTime;
   /** Content */
   gridContent?: Maybe<Array<ParagraphCardGridManualGridContentUnion>>;
+  gridContentUuids?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
@@ -964,7 +967,7 @@ export type ParagraphGoMaterialSliderAutomatic = ParagraphInterface & {
    * generated, by performing a query through the advanced search, and copying the
    * CQL string from there.
    */
-  cqlSearch: CqlSearch;
+  cqlSearch?: Maybe<CqlSearch>;
   /** The time that the Paragraph was created. */
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
@@ -1052,7 +1055,7 @@ export type ParagraphGoVideoBundleAutomatic = ParagraphInterface & {
    * generated, by performing a query through the advanced search, and copying the
    * CQL string from there.
    */
-  cqlSearch: CqlSearch;
+  cqlSearch?: Maybe<CqlSearch>;
   /** The time that the Paragraph was created. */
   created: DateTime;
   /** Embed video */
@@ -1181,18 +1184,10 @@ export type ParagraphManualEventList = ParagraphInterface & {
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/**
- * Please use the "Material grid link automatically" instead! This paragraph will be deprecated in the future.
- * A grid representation of recommended materials, based on a CQL search string.
- */
+/** A grid representation of recommended materials, based on a CQL string and filters. */
 export type ParagraphMaterialGridAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphMaterialGridAutomatic';
-  /**
-   * Determines the amount of materials that will be shown, based on the CQL
-   * string. <br /><br />Obs: If for example a CQL string has 11 results, and an
-   * editor chooses 12. The list will display 8 instead of 11, since the grid
-   * should be able to increment by 4.
-   */
+  /** @deprecated Use materialAmount instead */
   amountOfMaterials: Scalars['Int']['output'];
   /**
    * This field is for inserting a CQL string based on a search. <br /><br />Please
@@ -1201,13 +1196,15 @@ export type ParagraphMaterialGridAutomatic = ParagraphInterface & {
    * generated, by performing a query through the advanced search, and copying the
    * CQL string from there.
    */
-  cqlSearch: CqlSearch;
+  cqlSearch?: Maybe<CqlSearch>;
   /** The time that the Paragraph was created. */
   created: DateTime;
   /** The Universally Unique IDentifier (UUID). */
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
+  /** Amount of materials */
+  materialAmount: Scalars['Int']['output'];
   /** This is the optional description for the material grid. <br />Leave blank if you do not want a description. */
   materialGridDescription?: Maybe<Scalars['String']['output']>;
   /** The title for the material grid. Leave this blank if you do not want a title.  */
@@ -1219,12 +1216,7 @@ export type ParagraphMaterialGridAutomatic = ParagraphInterface & {
 /** A grid representation of recommended materials, based on a link search string.  */
 export type ParagraphMaterialGridLinkAutomatic = ParagraphInterface & {
   __typename?: 'ParagraphMaterialGridLinkAutomatic';
-  /**
-   * Determines the amount of materials that will be shown, based on the CQL
-   * string. <br /><br />Obs: If for example a CQL string has 11 results, and an
-   * editor chooses 12. The list will display 8 instead of 11, since the grid
-   * should be able to increment by 4.
-   */
+  /** @deprecated Use materialAmount instead */
   amountOfMaterials: Scalars['Int']['output'];
   /** The time that the Paragraph was created. */
   created: DateTime;
@@ -1232,6 +1224,8 @@ export type ParagraphMaterialGridLinkAutomatic = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
+  /** Amount of materials */
+  materialAmount: Scalars['Int']['output'];
   /** This is the optional description for the material grid. <br />Leave blank if you do not want a description. */
   materialGridDescription?: Maybe<Scalars['String']['output']>;
   /**
@@ -1261,10 +1255,10 @@ export type ParagraphMaterialGridManual = ParagraphInterface & {
   /** The title for the material grid. Leave this blank if you do not want a title.  */
   materialGridTitle?: Maybe<Scalars['String']['output']>;
   /**
-   * The grid will only display materials in internvals of 4. <br /><br />Example
-   * work ID: work-of:870970-basis:136336282.<br /><br />If you need to link to a
-   * specific type, select it from the dropdown and the system will display that,
-   * if it is available.
+   * Example work ID: work-of:870970-basis:136336282.<br /><br />If you need to
+   * link to a specific type, select it from the dropdown and the system will
+   * display that, if it is available. <strong>Supports a maximum of 32
+   * items.</strong>
    */
   materialGridWorkIds?: Maybe<Array<WorkId>>;
   /** Published */
@@ -1291,6 +1285,7 @@ export type ParagraphMedias = ParagraphInterface & {
 /** Entity type paragraph. */
 export type ParagraphNavGridManual = ParagraphInterface & {
   __typename?: 'ParagraphNavGridManual';
+  contentReferenceUuids?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** Contents */
   contentReferences?: Maybe<Array<ParagraphNavGridManualContentReferencesUnion>>;
   /** The time that the Paragraph was created. */
@@ -1303,6 +1298,8 @@ export type ParagraphNavGridManual = ParagraphInterface & {
   showSubtitles?: Maybe<Scalars['Boolean']['output']>;
   /** Published */
   status: Scalars['Boolean']['output'];
+  /** Title */
+  title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Contents */
@@ -1317,9 +1314,15 @@ export type ParagraphNavSpotsManual = ParagraphInterface & {
   id: Scalars['ID']['output'];
   /** The paragraphs entity language code. */
   langcode: Language;
+  /** Content */
+  navSpotsContent?: Maybe<Array<ParagraphNavSpotsManualNavSpotsContentUnion>>;
+  navSpotsContentUuids?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** Published */
   status: Scalars['Boolean']['output'];
 };
+
+/** Content */
+export type ParagraphNavSpotsManualNavSpotsContentUnion = NodeArticle | NodeGoArticle | NodeGoCategory | NodeGoPage | NodePage;
 
 /**
  * This is a paragraph for displaying the opening hours for the branch it is applied to.
@@ -1953,7 +1956,7 @@ export type WorkId = {
   __typename?: 'WorkId';
   /** Materialetype (fx bog, film, lydbog) */
   material_type?: Maybe<Scalars['String']['output']>;
-  /** The WorkID value */
+  /** Værk-ID */
   work_id?: Maybe<Scalars['String']['output']>;
 };
 
@@ -1961,27 +1964,433 @@ export type ImageFragmentFragment = { __typename?: 'MediaImage', name: string, b
 
 export type MediaVideotoolFragmentFragment = { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string };
 
-export type NodeGoPageFragment = { __typename: 'NodeGoPage', paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null };
+export type NodeGoPageFragment = { __typename: 'NodeGoPage', paragraphs?: Array<
+    | { __typename?: 'ParagraphAccordion' }
+    | { __typename?: 'ParagraphBanner' }
+    | { __typename?: 'ParagraphBreadcrumbChildren' }
+    | { __typename?: 'ParagraphCampaignRule' }
+    | { __typename?: 'ParagraphCardGridAutomatic' }
+    | { __typename?: 'ParagraphCardGridManual' }
+    | { __typename?: 'ParagraphContentSlider' }
+    | { __typename?: 'ParagraphContentSliderAutomatic' }
+    | { __typename?: 'ParagraphEventTicketCategory' }
+    | { __typename?: 'ParagraphFiles' }
+    | { __typename?: 'ParagraphFilteredEventList' }
+    | { __typename: 'ParagraphGoImages', goImages: Array<
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool' }
+      > }
+    | { __typename?: 'ParagraphGoLink' }
+    | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool' }
+       | null, goLinkParagraph:
+        | { __typename?: 'ParagraphAccordion' }
+        | { __typename?: 'ParagraphBanner' }
+        | { __typename?: 'ParagraphBreadcrumbChildren' }
+        | { __typename?: 'ParagraphCampaignRule' }
+        | { __typename?: 'ParagraphCardGridAutomatic' }
+        | { __typename?: 'ParagraphCardGridManual' }
+        | { __typename?: 'ParagraphContentSlider' }
+        | { __typename?: 'ParagraphContentSliderAutomatic' }
+        | { __typename?: 'ParagraphEventTicketCategory' }
+        | { __typename?: 'ParagraphFiles' }
+        | { __typename?: 'ParagraphFilteredEventList' }
+        | { __typename?: 'ParagraphGoImages' }
+        | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+        | { __typename?: 'ParagraphGoLinkbox' }
+        | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+        | { __typename?: 'ParagraphGoMaterialSliderManual' }
+        | { __typename?: 'ParagraphGoTextBody' }
+        | { __typename?: 'ParagraphGoVideo' }
+        | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+        | { __typename?: 'ParagraphGoVideoBundleManual' }
+        | { __typename?: 'ParagraphHero' }
+        | { __typename?: 'ParagraphLanguageSelector' }
+        | { __typename?: 'ParagraphLinks' }
+        | { __typename?: 'ParagraphManualEventList' }
+        | { __typename?: 'ParagraphMaterialGridAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridManual' }
+        | { __typename?: 'ParagraphMedias' }
+        | { __typename?: 'ParagraphNavGridManual' }
+        | { __typename?: 'ParagraphNavSpotsManual' }
+        | { __typename?: 'ParagraphOpeningHours' }
+        | { __typename?: 'ParagraphRecommendation' }
+        | { __typename?: 'ParagraphSimpleLinks' }
+        | { __typename?: 'ParagraphTextBody' }
+        | { __typename?: 'ParagraphUserRegistrationItem' }
+        | { __typename?: 'ParagraphUserRegistrationLinklist' }
+        | { __typename?: 'ParagraphUserRegistrationSection' }
+        | { __typename?: 'ParagraphVideo' }
+        | { __typename?: 'ParagraphWebform' }
+       }
+    | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+    | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+    | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+    | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+       }
+    | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+       }
+    | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+      , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+    | { __typename?: 'ParagraphHero' }
+    | { __typename?: 'ParagraphLanguageSelector' }
+    | { __typename?: 'ParagraphLinks' }
+    | { __typename?: 'ParagraphManualEventList' }
+    | { __typename?: 'ParagraphMaterialGridAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridManual' }
+    | { __typename?: 'ParagraphMedias' }
+    | { __typename?: 'ParagraphNavGridManual' }
+    | { __typename?: 'ParagraphNavSpotsManual' }
+    | { __typename?: 'ParagraphOpeningHours' }
+    | { __typename?: 'ParagraphRecommendation' }
+    | { __typename?: 'ParagraphSimpleLinks' }
+    | { __typename?: 'ParagraphTextBody' }
+    | { __typename?: 'ParagraphUserRegistrationItem' }
+    | { __typename?: 'ParagraphUserRegistrationLinklist' }
+    | { __typename?: 'ParagraphUserRegistrationSection' }
+    | { __typename?: 'ParagraphVideo' }
+    | { __typename?: 'ParagraphWebform' }
+  > | null };
 
-export type NodeGoArticleFragment = { __typename: 'NodeGoArticle', id: string, title: string, subtitle?: string | null, goArticleImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, publicationDate: { __typename?: 'DateTime', timestamp: unknown }, paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null };
+export type NodeGoArticleFragment = { __typename: 'NodeGoArticle', id: string, title: string, subtitle?: string | null, goArticleImage?:
+    | { __typename?: 'MediaAudio' }
+    | { __typename?: 'MediaDocument' }
+    | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+    | { __typename?: 'MediaVideo' }
+    | { __typename?: 'MediaVideotool' }
+   | null, publicationDate: { __typename?: 'DateTime', timestamp: unknown }, paragraphs?: Array<
+    | { __typename?: 'ParagraphAccordion' }
+    | { __typename?: 'ParagraphBanner' }
+    | { __typename?: 'ParagraphBreadcrumbChildren' }
+    | { __typename?: 'ParagraphCampaignRule' }
+    | { __typename?: 'ParagraphCardGridAutomatic' }
+    | { __typename?: 'ParagraphCardGridManual' }
+    | { __typename?: 'ParagraphContentSlider' }
+    | { __typename?: 'ParagraphContentSliderAutomatic' }
+    | { __typename?: 'ParagraphEventTicketCategory' }
+    | { __typename?: 'ParagraphFiles' }
+    | { __typename?: 'ParagraphFilteredEventList' }
+    | { __typename: 'ParagraphGoImages', goImages: Array<
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool' }
+      > }
+    | { __typename?: 'ParagraphGoLink' }
+    | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool' }
+       | null, goLinkParagraph:
+        | { __typename?: 'ParagraphAccordion' }
+        | { __typename?: 'ParagraphBanner' }
+        | { __typename?: 'ParagraphBreadcrumbChildren' }
+        | { __typename?: 'ParagraphCampaignRule' }
+        | { __typename?: 'ParagraphCardGridAutomatic' }
+        | { __typename?: 'ParagraphCardGridManual' }
+        | { __typename?: 'ParagraphContentSlider' }
+        | { __typename?: 'ParagraphContentSliderAutomatic' }
+        | { __typename?: 'ParagraphEventTicketCategory' }
+        | { __typename?: 'ParagraphFiles' }
+        | { __typename?: 'ParagraphFilteredEventList' }
+        | { __typename?: 'ParagraphGoImages' }
+        | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+        | { __typename?: 'ParagraphGoLinkbox' }
+        | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+        | { __typename?: 'ParagraphGoMaterialSliderManual' }
+        | { __typename?: 'ParagraphGoTextBody' }
+        | { __typename?: 'ParagraphGoVideo' }
+        | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+        | { __typename?: 'ParagraphGoVideoBundleManual' }
+        | { __typename?: 'ParagraphHero' }
+        | { __typename?: 'ParagraphLanguageSelector' }
+        | { __typename?: 'ParagraphLinks' }
+        | { __typename?: 'ParagraphManualEventList' }
+        | { __typename?: 'ParagraphMaterialGridAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridManual' }
+        | { __typename?: 'ParagraphMedias' }
+        | { __typename?: 'ParagraphNavGridManual' }
+        | { __typename?: 'ParagraphNavSpotsManual' }
+        | { __typename?: 'ParagraphOpeningHours' }
+        | { __typename?: 'ParagraphRecommendation' }
+        | { __typename?: 'ParagraphSimpleLinks' }
+        | { __typename?: 'ParagraphTextBody' }
+        | { __typename?: 'ParagraphUserRegistrationItem' }
+        | { __typename?: 'ParagraphUserRegistrationLinklist' }
+        | { __typename?: 'ParagraphUserRegistrationSection' }
+        | { __typename?: 'ParagraphVideo' }
+        | { __typename?: 'ParagraphWebform' }
+       }
+    | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+    | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+    | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+    | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+       }
+    | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+       }
+    | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+      , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+    | { __typename?: 'ParagraphHero' }
+    | { __typename?: 'ParagraphLanguageSelector' }
+    | { __typename?: 'ParagraphLinks' }
+    | { __typename?: 'ParagraphManualEventList' }
+    | { __typename?: 'ParagraphMaterialGridAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridManual' }
+    | { __typename?: 'ParagraphMedias' }
+    | { __typename?: 'ParagraphNavGridManual' }
+    | { __typename?: 'ParagraphNavSpotsManual' }
+    | { __typename?: 'ParagraphOpeningHours' }
+    | { __typename?: 'ParagraphRecommendation' }
+    | { __typename?: 'ParagraphSimpleLinks' }
+    | { __typename?: 'ParagraphTextBody' }
+    | { __typename?: 'ParagraphUserRegistrationItem' }
+    | { __typename?: 'ParagraphUserRegistrationLinklist' }
+    | { __typename?: 'ParagraphUserRegistrationSection' }
+    | { __typename?: 'ParagraphVideo' }
+    | { __typename?: 'ParagraphWebform' }
+  > | null };
 
-export type NodeGoCategoryFragment = { __typename: 'NodeGoCategory', id: string, path?: string | null, title: string, paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null };
+export type NodeGoCategoryFragment = { __typename: 'NodeGoCategory', id: string, path?: string | null, title: string, paragraphs?: Array<
+    | { __typename?: 'ParagraphAccordion' }
+    | { __typename?: 'ParagraphBanner' }
+    | { __typename?: 'ParagraphBreadcrumbChildren' }
+    | { __typename?: 'ParagraphCampaignRule' }
+    | { __typename?: 'ParagraphCardGridAutomatic' }
+    | { __typename?: 'ParagraphCardGridManual' }
+    | { __typename?: 'ParagraphContentSlider' }
+    | { __typename?: 'ParagraphContentSliderAutomatic' }
+    | { __typename?: 'ParagraphEventTicketCategory' }
+    | { __typename?: 'ParagraphFiles' }
+    | { __typename?: 'ParagraphFilteredEventList' }
+    | { __typename: 'ParagraphGoImages', goImages: Array<
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool' }
+      > }
+    | { __typename?: 'ParagraphGoLink' }
+    | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool' }
+       | null, goLinkParagraph:
+        | { __typename?: 'ParagraphAccordion' }
+        | { __typename?: 'ParagraphBanner' }
+        | { __typename?: 'ParagraphBreadcrumbChildren' }
+        | { __typename?: 'ParagraphCampaignRule' }
+        | { __typename?: 'ParagraphCardGridAutomatic' }
+        | { __typename?: 'ParagraphCardGridManual' }
+        | { __typename?: 'ParagraphContentSlider' }
+        | { __typename?: 'ParagraphContentSliderAutomatic' }
+        | { __typename?: 'ParagraphEventTicketCategory' }
+        | { __typename?: 'ParagraphFiles' }
+        | { __typename?: 'ParagraphFilteredEventList' }
+        | { __typename?: 'ParagraphGoImages' }
+        | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+        | { __typename?: 'ParagraphGoLinkbox' }
+        | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+        | { __typename?: 'ParagraphGoMaterialSliderManual' }
+        | { __typename?: 'ParagraphGoTextBody' }
+        | { __typename?: 'ParagraphGoVideo' }
+        | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+        | { __typename?: 'ParagraphGoVideoBundleManual' }
+        | { __typename?: 'ParagraphHero' }
+        | { __typename?: 'ParagraphLanguageSelector' }
+        | { __typename?: 'ParagraphLinks' }
+        | { __typename?: 'ParagraphManualEventList' }
+        | { __typename?: 'ParagraphMaterialGridAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridManual' }
+        | { __typename?: 'ParagraphMedias' }
+        | { __typename?: 'ParagraphNavGridManual' }
+        | { __typename?: 'ParagraphNavSpotsManual' }
+        | { __typename?: 'ParagraphOpeningHours' }
+        | { __typename?: 'ParagraphRecommendation' }
+        | { __typename?: 'ParagraphSimpleLinks' }
+        | { __typename?: 'ParagraphTextBody' }
+        | { __typename?: 'ParagraphUserRegistrationItem' }
+        | { __typename?: 'ParagraphUserRegistrationLinklist' }
+        | { __typename?: 'ParagraphUserRegistrationSection' }
+        | { __typename?: 'ParagraphVideo' }
+        | { __typename?: 'ParagraphWebform' }
+       }
+    | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+    | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+    | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+    | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+       }
+    | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+       }
+    | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage' }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+      , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+    | { __typename?: 'ParagraphHero' }
+    | { __typename?: 'ParagraphLanguageSelector' }
+    | { __typename?: 'ParagraphLinks' }
+    | { __typename?: 'ParagraphManualEventList' }
+    | { __typename?: 'ParagraphMaterialGridAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridManual' }
+    | { __typename?: 'ParagraphMedias' }
+    | { __typename?: 'ParagraphNavGridManual' }
+    | { __typename?: 'ParagraphNavSpotsManual' }
+    | { __typename?: 'ParagraphOpeningHours' }
+    | { __typename?: 'ParagraphRecommendation' }
+    | { __typename?: 'ParagraphSimpleLinks' }
+    | { __typename?: 'ParagraphTextBody' }
+    | { __typename?: 'ParagraphUserRegistrationItem' }
+    | { __typename?: 'ParagraphUserRegistrationLinklist' }
+    | { __typename?: 'ParagraphUserRegistrationSection' }
+    | { __typename?: 'ParagraphVideo' }
+    | { __typename?: 'ParagraphWebform' }
+  > | null };
 
-export type GoVideoFragment = { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } };
+export type GoVideoFragment = { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+    | { __typename?: 'MediaAudio' }
+    | { __typename?: 'MediaDocument' }
+    | { __typename?: 'MediaImage' }
+    | { __typename?: 'MediaVideo' }
+    | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+   };
 
-export type GoVideoBundleAutomaticFragment = { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } };
+export type GoVideoBundleAutomaticFragment = { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+    | { __typename?: 'MediaAudio' }
+    | { __typename?: 'MediaDocument' }
+    | { __typename?: 'MediaImage' }
+    | { __typename?: 'MediaVideo' }
+    | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+   };
 
-export type GoVideoBundleManualFragment = { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null };
+export type GoVideoBundleManualFragment = { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+    | { __typename?: 'MediaAudio' }
+    | { __typename?: 'MediaDocument' }
+    | { __typename?: 'MediaImage' }
+    | { __typename?: 'MediaVideo' }
+    | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+  , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null };
 
-export type GoMaterialSliderAutomaticFragment = { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } };
+export type GoMaterialSliderAutomaticFragment = { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null };
 
 export type GoMaterialSliderManualFragment = { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> };
 
-export type GoLinkboxFragment = { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } };
+export type GoLinkboxFragment = { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+    | { __typename?: 'MediaAudio' }
+    | { __typename?: 'MediaDocument' }
+    | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+    | { __typename?: 'MediaVideo' }
+    | { __typename?: 'MediaVideotool' }
+   | null, goLinkParagraph:
+    | { __typename?: 'ParagraphAccordion' }
+    | { __typename?: 'ParagraphBanner' }
+    | { __typename?: 'ParagraphBreadcrumbChildren' }
+    | { __typename?: 'ParagraphCampaignRule' }
+    | { __typename?: 'ParagraphCardGridAutomatic' }
+    | { __typename?: 'ParagraphCardGridManual' }
+    | { __typename?: 'ParagraphContentSlider' }
+    | { __typename?: 'ParagraphContentSliderAutomatic' }
+    | { __typename?: 'ParagraphEventTicketCategory' }
+    | { __typename?: 'ParagraphFiles' }
+    | { __typename?: 'ParagraphFilteredEventList' }
+    | { __typename?: 'ParagraphGoImages' }
+    | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+    | { __typename?: 'ParagraphGoLinkbox' }
+    | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+    | { __typename?: 'ParagraphGoMaterialSliderManual' }
+    | { __typename?: 'ParagraphGoTextBody' }
+    | { __typename?: 'ParagraphGoVideo' }
+    | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+    | { __typename?: 'ParagraphGoVideoBundleManual' }
+    | { __typename?: 'ParagraphHero' }
+    | { __typename?: 'ParagraphLanguageSelector' }
+    | { __typename?: 'ParagraphLinks' }
+    | { __typename?: 'ParagraphManualEventList' }
+    | { __typename?: 'ParagraphMaterialGridAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+    | { __typename?: 'ParagraphMaterialGridManual' }
+    | { __typename?: 'ParagraphMedias' }
+    | { __typename?: 'ParagraphNavGridManual' }
+    | { __typename?: 'ParagraphNavSpotsManual' }
+    | { __typename?: 'ParagraphOpeningHours' }
+    | { __typename?: 'ParagraphRecommendation' }
+    | { __typename?: 'ParagraphSimpleLinks' }
+    | { __typename?: 'ParagraphTextBody' }
+    | { __typename?: 'ParagraphUserRegistrationItem' }
+    | { __typename?: 'ParagraphUserRegistrationLinklist' }
+    | { __typename?: 'ParagraphUserRegistrationSection' }
+    | { __typename?: 'ParagraphVideo' }
+    | { __typename?: 'ParagraphWebform' }
+   };
 
 export type GoTextBodyFragment = { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } };
 
-export type GoImagesFragment = { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> };
+export type GoImagesFragment = { __typename: 'ParagraphGoImages', goImages: Array<
+    | { __typename?: 'MediaAudio' }
+    | { __typename?: 'MediaDocument' }
+    | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+    | { __typename?: 'MediaVideo' }
+    | { __typename?: 'MediaVideotool' }
+  > };
 
 export type RouteRedirectFragment = { __typename: 'RouteRedirect', url: string };
 
@@ -1990,19 +2399,275 @@ export type GetArticleByPathQueryVariables = Exact<{
 }>;
 
 
-export type GetArticleByPathQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', route?: { __typename: 'RouteExternal' } | { __typename: 'RouteInternal', url: string, entity?: { __typename: 'NodeGoArticle', id: string, title: string, subtitle?: string | null, goArticleImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, publicationDate: { __typename?: 'DateTime', timestamp: unknown }, paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null } | { __typename?: 'NodeGoCategory' } | { __typename?: 'NodeGoPage' } | { __typename?: 'NodePage' } | null } | { __typename: 'RouteRedirect', url: string } | null };
+export type GetArticleByPathQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', route?:
+    | { __typename: 'RouteExternal' }
+    | { __typename: 'RouteInternal', url: string, entity?:
+        | { __typename: 'NodeGoArticle', id: string, title: string, subtitle?: string | null, goArticleImage?:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool' }
+           | null, publicationDate: { __typename?: 'DateTime', timestamp: unknown }, paragraphs?: Array<
+            | { __typename?: 'ParagraphAccordion' }
+            | { __typename?: 'ParagraphBanner' }
+            | { __typename?: 'ParagraphBreadcrumbChildren' }
+            | { __typename?: 'ParagraphCampaignRule' }
+            | { __typename?: 'ParagraphCardGridAutomatic' }
+            | { __typename?: 'ParagraphCardGridManual' }
+            | { __typename?: 'ParagraphContentSlider' }
+            | { __typename?: 'ParagraphContentSliderAutomatic' }
+            | { __typename?: 'ParagraphEventTicketCategory' }
+            | { __typename?: 'ParagraphFiles' }
+            | { __typename?: 'ParagraphFilteredEventList' }
+            | { __typename: 'ParagraphGoImages', goImages: Array<
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool' }
+              > }
+            | { __typename?: 'ParagraphGoLink' }
+            | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool' }
+               | null, goLinkParagraph:
+                | { __typename?: 'ParagraphAccordion' }
+                | { __typename?: 'ParagraphBanner' }
+                | { __typename?: 'ParagraphBreadcrumbChildren' }
+                | { __typename?: 'ParagraphCampaignRule' }
+                | { __typename?: 'ParagraphCardGridAutomatic' }
+                | { __typename?: 'ParagraphCardGridManual' }
+                | { __typename?: 'ParagraphContentSlider' }
+                | { __typename?: 'ParagraphContentSliderAutomatic' }
+                | { __typename?: 'ParagraphEventTicketCategory' }
+                | { __typename?: 'ParagraphFiles' }
+                | { __typename?: 'ParagraphFilteredEventList' }
+                | { __typename?: 'ParagraphGoImages' }
+                | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+                | { __typename?: 'ParagraphGoLinkbox' }
+                | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+                | { __typename?: 'ParagraphGoMaterialSliderManual' }
+                | { __typename?: 'ParagraphGoTextBody' }
+                | { __typename?: 'ParagraphGoVideo' }
+                | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+                | { __typename?: 'ParagraphGoVideoBundleManual' }
+                | { __typename?: 'ParagraphHero' }
+                | { __typename?: 'ParagraphLanguageSelector' }
+                | { __typename?: 'ParagraphLinks' }
+                | { __typename?: 'ParagraphManualEventList' }
+                | { __typename?: 'ParagraphMaterialGridAutomatic' }
+                | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+                | { __typename?: 'ParagraphMaterialGridManual' }
+                | { __typename?: 'ParagraphMedias' }
+                | { __typename?: 'ParagraphNavGridManual' }
+                | { __typename?: 'ParagraphNavSpotsManual' }
+                | { __typename?: 'ParagraphOpeningHours' }
+                | { __typename?: 'ParagraphRecommendation' }
+                | { __typename?: 'ParagraphSimpleLinks' }
+                | { __typename?: 'ParagraphTextBody' }
+                | { __typename?: 'ParagraphUserRegistrationItem' }
+                | { __typename?: 'ParagraphUserRegistrationLinklist' }
+                | { __typename?: 'ParagraphUserRegistrationSection' }
+                | { __typename?: 'ParagraphVideo' }
+                | { __typename?: 'ParagraphWebform' }
+               }
+            | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+            | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+            | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+            | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+               }
+            | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+               }
+            | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+              , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+            | { __typename?: 'ParagraphHero' }
+            | { __typename?: 'ParagraphLanguageSelector' }
+            | { __typename?: 'ParagraphLinks' }
+            | { __typename?: 'ParagraphManualEventList' }
+            | { __typename?: 'ParagraphMaterialGridAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridManual' }
+            | { __typename?: 'ParagraphMedias' }
+            | { __typename?: 'ParagraphNavGridManual' }
+            | { __typename?: 'ParagraphNavSpotsManual' }
+            | { __typename?: 'ParagraphOpeningHours' }
+            | { __typename?: 'ParagraphRecommendation' }
+            | { __typename?: 'ParagraphSimpleLinks' }
+            | { __typename?: 'ParagraphTextBody' }
+            | { __typename?: 'ParagraphUserRegistrationItem' }
+            | { __typename?: 'ParagraphUserRegistrationLinklist' }
+            | { __typename?: 'ParagraphUserRegistrationSection' }
+            | { __typename?: 'ParagraphVideo' }
+            | { __typename?: 'ParagraphWebform' }
+          > | null }
+        | { __typename?: 'NodeGoCategory' }
+        | { __typename?: 'NodeGoPage' }
+        | { __typename?: 'NodePage' }
+       | null }
+    | { __typename: 'RouteRedirect', url: string }
+   | null };
 
 export type GetCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCategoriesQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goCategories?: { __typename?: 'GoCategoriesResult', results: Array<{ __typename?: 'NodeArticle' } | { __typename?: 'NodeGoArticle' } | { __typename?: 'NodeGoCategory', id: string, path?: string | null, categoryMenuTitle: string, categoryMenuImage: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }, changed: { __typename?: 'DateTime', timestamp: unknown } } | { __typename?: 'NodeGoPage' } | { __typename?: 'NodePage' }> } | null };
+export type GetCategoriesQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goCategories?: { __typename?: 'GoCategoriesResult', results: Array<
+      | { __typename?: 'NodeArticle' }
+      | { __typename?: 'NodeGoArticle' }
+      | { __typename?: 'NodeGoCategory', id: string, path?: string | null, categoryMenuTitle: string, categoryMenuImage:
+          | { __typename?: 'MediaAudio' }
+          | { __typename?: 'MediaDocument' }
+          | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+          | { __typename?: 'MediaVideo' }
+          | { __typename?: 'MediaVideotool' }
+        , changed: { __typename?: 'DateTime', timestamp: unknown } }
+      | { __typename?: 'NodeGoPage' }
+      | { __typename?: 'NodePage' }
+    > } | null };
 
 export type GetCategoryPageByPathQueryVariables = Exact<{
   path: Scalars['String']['input'];
 }>;
 
 
-export type GetCategoryPageByPathQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', route?: { __typename: 'RouteExternal' } | { __typename: 'RouteInternal', url: string, entity?: { __typename?: 'NodeGoArticle' } | { __typename: 'NodeGoCategory', id: string, path?: string | null, title: string, paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null } | { __typename?: 'NodeGoPage' } | { __typename?: 'NodePage' } | null } | { __typename: 'RouteRedirect', url: string } | null };
+export type GetCategoryPageByPathQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', route?:
+    | { __typename: 'RouteExternal' }
+    | { __typename: 'RouteInternal', url: string, entity?:
+        | { __typename?: 'NodeGoArticle' }
+        | { __typename: 'NodeGoCategory', id: string, path?: string | null, title: string, paragraphs?: Array<
+            | { __typename?: 'ParagraphAccordion' }
+            | { __typename?: 'ParagraphBanner' }
+            | { __typename?: 'ParagraphBreadcrumbChildren' }
+            | { __typename?: 'ParagraphCampaignRule' }
+            | { __typename?: 'ParagraphCardGridAutomatic' }
+            | { __typename?: 'ParagraphCardGridManual' }
+            | { __typename?: 'ParagraphContentSlider' }
+            | { __typename?: 'ParagraphContentSliderAutomatic' }
+            | { __typename?: 'ParagraphEventTicketCategory' }
+            | { __typename?: 'ParagraphFiles' }
+            | { __typename?: 'ParagraphFilteredEventList' }
+            | { __typename: 'ParagraphGoImages', goImages: Array<
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool' }
+              > }
+            | { __typename?: 'ParagraphGoLink' }
+            | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool' }
+               | null, goLinkParagraph:
+                | { __typename?: 'ParagraphAccordion' }
+                | { __typename?: 'ParagraphBanner' }
+                | { __typename?: 'ParagraphBreadcrumbChildren' }
+                | { __typename?: 'ParagraphCampaignRule' }
+                | { __typename?: 'ParagraphCardGridAutomatic' }
+                | { __typename?: 'ParagraphCardGridManual' }
+                | { __typename?: 'ParagraphContentSlider' }
+                | { __typename?: 'ParagraphContentSliderAutomatic' }
+                | { __typename?: 'ParagraphEventTicketCategory' }
+                | { __typename?: 'ParagraphFiles' }
+                | { __typename?: 'ParagraphFilteredEventList' }
+                | { __typename?: 'ParagraphGoImages' }
+                | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+                | { __typename?: 'ParagraphGoLinkbox' }
+                | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+                | { __typename?: 'ParagraphGoMaterialSliderManual' }
+                | { __typename?: 'ParagraphGoTextBody' }
+                | { __typename?: 'ParagraphGoVideo' }
+                | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+                | { __typename?: 'ParagraphGoVideoBundleManual' }
+                | { __typename?: 'ParagraphHero' }
+                | { __typename?: 'ParagraphLanguageSelector' }
+                | { __typename?: 'ParagraphLinks' }
+                | { __typename?: 'ParagraphManualEventList' }
+                | { __typename?: 'ParagraphMaterialGridAutomatic' }
+                | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+                | { __typename?: 'ParagraphMaterialGridManual' }
+                | { __typename?: 'ParagraphMedias' }
+                | { __typename?: 'ParagraphNavGridManual' }
+                | { __typename?: 'ParagraphNavSpotsManual' }
+                | { __typename?: 'ParagraphOpeningHours' }
+                | { __typename?: 'ParagraphRecommendation' }
+                | { __typename?: 'ParagraphSimpleLinks' }
+                | { __typename?: 'ParagraphTextBody' }
+                | { __typename?: 'ParagraphUserRegistrationItem' }
+                | { __typename?: 'ParagraphUserRegistrationLinklist' }
+                | { __typename?: 'ParagraphUserRegistrationSection' }
+                | { __typename?: 'ParagraphVideo' }
+                | { __typename?: 'ParagraphWebform' }
+               }
+            | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+            | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+            | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+            | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+               }
+            | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+               }
+            | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+              , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+            | { __typename?: 'ParagraphHero' }
+            | { __typename?: 'ParagraphLanguageSelector' }
+            | { __typename?: 'ParagraphLinks' }
+            | { __typename?: 'ParagraphManualEventList' }
+            | { __typename?: 'ParagraphMaterialGridAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridManual' }
+            | { __typename?: 'ParagraphMedias' }
+            | { __typename?: 'ParagraphNavGridManual' }
+            | { __typename?: 'ParagraphNavSpotsManual' }
+            | { __typename?: 'ParagraphOpeningHours' }
+            | { __typename?: 'ParagraphRecommendation' }
+            | { __typename?: 'ParagraphSimpleLinks' }
+            | { __typename?: 'ParagraphTextBody' }
+            | { __typename?: 'ParagraphUserRegistrationItem' }
+            | { __typename?: 'ParagraphUserRegistrationLinklist' }
+            | { __typename?: 'ParagraphUserRegistrationSection' }
+            | { __typename?: 'ParagraphVideo' }
+            | { __typename?: 'ParagraphWebform' }
+          > | null }
+        | { __typename?: 'NodeGoPage' }
+        | { __typename?: 'NodePage' }
+       | null }
+    | { __typename: 'RouteRedirect', url: string }
+   | null };
 
 export type GetDplCmsPrivateConfigurationQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2012,14 +2677,133 @@ export type GetDplCmsPrivateConfigurationQuery = { go: { cacheTags: string[] } }
 export type GetDplCmsPublicConfigurationQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetDplCmsPublicConfigurationQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', public?: { __typename?: 'GoConfigurationPublic', searchProfiles?: { __typename?: 'SearchProfiles', local?: string | null } | null, libraryInfo?: { __typename?: 'GoLibraryInfo', name?: string | null } | null, loginUrls?: { __typename?: 'GoLoginUrls', adgangsplatformen?: string | null } | null, logoutUrls?: { __typename?: 'GoLogoutUrls', adgangsplatformen?: string | null } | null, unilogin?: { __typename?: 'UniloginConfigurationPublic', municipalityId?: string | null } | null } | null } | null };
+export type GetDplCmsPublicConfigurationQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', goConfiguration?: { __typename?: 'GoConfiguration', public?: { __typename?: 'GoConfigurationPublic', libraryInfo?: { __typename?: 'GoLibraryInfo', name?: string | null } | null, loginUrls?: { __typename?: 'GoLoginUrls', adgangsplatformen?: string | null } | null, logoutUrls?: { __typename?: 'GoLogoutUrls', adgangsplatformen?: string | null } | null, unilogin?: { __typename?: 'UniloginConfigurationPublic', municipalityId?: string | null } | null } | null } | null };
 
 export type GetPageByPathQueryVariables = Exact<{
   path: Scalars['String']['input'];
 }>;
 
 
-export type GetPageByPathQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', route?: { __typename: 'RouteExternal' } | { __typename: 'RouteInternal', url: string, entity?: { __typename?: 'NodeGoArticle' } | { __typename?: 'NodeGoCategory' } | { __typename: 'NodeGoPage', paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null } | { __typename?: 'NodePage' } | null } | { __typename: 'RouteRedirect', url: string } | null };
+export type GetPageByPathQuery = { go: { cacheTags: string[] } } & { __typename?: 'Query', route?:
+    | { __typename: 'RouteExternal' }
+    | { __typename: 'RouteInternal', url: string, entity?:
+        | { __typename?: 'NodeGoArticle' }
+        | { __typename?: 'NodeGoCategory' }
+        | { __typename: 'NodeGoPage', paragraphs?: Array<
+            | { __typename?: 'ParagraphAccordion' }
+            | { __typename?: 'ParagraphBanner' }
+            | { __typename?: 'ParagraphBreadcrumbChildren' }
+            | { __typename?: 'ParagraphCampaignRule' }
+            | { __typename?: 'ParagraphCardGridAutomatic' }
+            | { __typename?: 'ParagraphCardGridManual' }
+            | { __typename?: 'ParagraphContentSlider' }
+            | { __typename?: 'ParagraphContentSliderAutomatic' }
+            | { __typename?: 'ParagraphEventTicketCategory' }
+            | { __typename?: 'ParagraphFiles' }
+            | { __typename?: 'ParagraphFilteredEventList' }
+            | { __typename: 'ParagraphGoImages', goImages: Array<
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool' }
+              > }
+            | { __typename?: 'ParagraphGoLink' }
+            | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool' }
+               | null, goLinkParagraph:
+                | { __typename?: 'ParagraphAccordion' }
+                | { __typename?: 'ParagraphBanner' }
+                | { __typename?: 'ParagraphBreadcrumbChildren' }
+                | { __typename?: 'ParagraphCampaignRule' }
+                | { __typename?: 'ParagraphCardGridAutomatic' }
+                | { __typename?: 'ParagraphCardGridManual' }
+                | { __typename?: 'ParagraphContentSlider' }
+                | { __typename?: 'ParagraphContentSliderAutomatic' }
+                | { __typename?: 'ParagraphEventTicketCategory' }
+                | { __typename?: 'ParagraphFiles' }
+                | { __typename?: 'ParagraphFilteredEventList' }
+                | { __typename?: 'ParagraphGoImages' }
+                | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+                | { __typename?: 'ParagraphGoLinkbox' }
+                | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+                | { __typename?: 'ParagraphGoMaterialSliderManual' }
+                | { __typename?: 'ParagraphGoTextBody' }
+                | { __typename?: 'ParagraphGoVideo' }
+                | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+                | { __typename?: 'ParagraphGoVideoBundleManual' }
+                | { __typename?: 'ParagraphHero' }
+                | { __typename?: 'ParagraphLanguageSelector' }
+                | { __typename?: 'ParagraphLinks' }
+                | { __typename?: 'ParagraphManualEventList' }
+                | { __typename?: 'ParagraphMaterialGridAutomatic' }
+                | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+                | { __typename?: 'ParagraphMaterialGridManual' }
+                | { __typename?: 'ParagraphMedias' }
+                | { __typename?: 'ParagraphNavGridManual' }
+                | { __typename?: 'ParagraphNavSpotsManual' }
+                | { __typename?: 'ParagraphOpeningHours' }
+                | { __typename?: 'ParagraphRecommendation' }
+                | { __typename?: 'ParagraphSimpleLinks' }
+                | { __typename?: 'ParagraphTextBody' }
+                | { __typename?: 'ParagraphUserRegistrationItem' }
+                | { __typename?: 'ParagraphUserRegistrationLinklist' }
+                | { __typename?: 'ParagraphUserRegistrationSection' }
+                | { __typename?: 'ParagraphVideo' }
+                | { __typename?: 'ParagraphWebform' }
+               }
+            | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+            | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+            | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+            | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+               }
+            | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+               }
+            | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+                | { __typename?: 'MediaAudio' }
+                | { __typename?: 'MediaDocument' }
+                | { __typename?: 'MediaImage' }
+                | { __typename?: 'MediaVideo' }
+                | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+              , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+            | { __typename?: 'ParagraphHero' }
+            | { __typename?: 'ParagraphLanguageSelector' }
+            | { __typename?: 'ParagraphLinks' }
+            | { __typename?: 'ParagraphManualEventList' }
+            | { __typename?: 'ParagraphMaterialGridAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridManual' }
+            | { __typename?: 'ParagraphMedias' }
+            | { __typename?: 'ParagraphNavGridManual' }
+            | { __typename?: 'ParagraphNavSpotsManual' }
+            | { __typename?: 'ParagraphOpeningHours' }
+            | { __typename?: 'ParagraphRecommendation' }
+            | { __typename?: 'ParagraphSimpleLinks' }
+            | { __typename?: 'ParagraphTextBody' }
+            | { __typename?: 'ParagraphUserRegistrationItem' }
+            | { __typename?: 'ParagraphUserRegistrationLinklist' }
+            | { __typename?: 'ParagraphUserRegistrationSection' }
+            | { __typename?: 'ParagraphVideo' }
+            | { __typename?: 'ParagraphWebform' }
+          > | null }
+        | { __typename?: 'NodePage' }
+       | null }
+    | { __typename: 'RouteRedirect', url: string }
+   | null };
 
 export type GetPreviewPageByIddQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -2027,7 +2811,349 @@ export type GetPreviewPageByIddQueryVariables = Exact<{
 }>;
 
 
-export type GetPreviewPageByIddQuery = { go: { cacheTags: string[] } } & { __typename: 'Query', preview?: { __typename: 'NodeArticle' } | { __typename: 'NodeGoArticle', id: string, title: string, subtitle?: string | null, goArticleImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, publicationDate: { __typename?: 'DateTime', timestamp: unknown }, paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null } | { __typename: 'NodeGoCategory', id: string, path?: string | null, title: string, paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null } | { __typename: 'NodeGoPage', paragraphs?: Array<{ __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename: 'ParagraphGoImages', goImages: Array<{ __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' }> } | { __typename?: 'ParagraphGoLink' } | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool' } | null, goLinkParagraph: { __typename?: 'ParagraphAccordion' } | { __typename?: 'ParagraphBanner' } | { __typename?: 'ParagraphBreadcrumbChildren' } | { __typename?: 'ParagraphCampaignRule' } | { __typename?: 'ParagraphCardGridAutomatic' } | { __typename?: 'ParagraphCardGridManual' } | { __typename?: 'ParagraphContentSlider' } | { __typename?: 'ParagraphContentSliderAutomatic' } | { __typename?: 'ParagraphEventTicketCategory' } | { __typename?: 'ParagraphFiles' } | { __typename?: 'ParagraphFilteredEventList' } | { __typename?: 'ParagraphGoImages' } | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } } | { __typename?: 'ParagraphGoLinkbox' } | { __typename?: 'ParagraphGoMaterialSliderAutomatic' } | { __typename?: 'ParagraphGoMaterialSliderManual' } | { __typename?: 'ParagraphGoTextBody' } | { __typename?: 'ParagraphGoVideo' } | { __typename?: 'ParagraphGoVideoBundleAutomatic' } | { __typename?: 'ParagraphGoVideoBundleManual' } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' } } | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null } } | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> } | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } } | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch: { __typename?: 'CQLSearch', value?: string | null }, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string } } | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo: { __typename?: 'MediaAudio' } | { __typename?: 'MediaDocument' } | { __typename?: 'MediaImage' } | { __typename?: 'MediaVideo' } | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }, videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null } | { __typename?: 'ParagraphHero' } | { __typename?: 'ParagraphLanguageSelector' } | { __typename?: 'ParagraphLinks' } | { __typename?: 'ParagraphManualEventList' } | { __typename?: 'ParagraphMaterialGridAutomatic' } | { __typename?: 'ParagraphMaterialGridLinkAutomatic' } | { __typename?: 'ParagraphMaterialGridManual' } | { __typename?: 'ParagraphMedias' } | { __typename?: 'ParagraphNavGridManual' } | { __typename?: 'ParagraphNavSpotsManual' } | { __typename?: 'ParagraphOpeningHours' } | { __typename?: 'ParagraphRecommendation' } | { __typename?: 'ParagraphSimpleLinks' } | { __typename?: 'ParagraphTextBody' } | { __typename?: 'ParagraphUserRegistrationItem' } | { __typename?: 'ParagraphUserRegistrationLinklist' } | { __typename?: 'ParagraphUserRegistrationSection' } | { __typename?: 'ParagraphVideo' } | { __typename?: 'ParagraphWebform' }> | null } | { __typename: 'NodePage' } | null };
+export type GetPreviewPageByIddQuery = { go: { cacheTags: string[] } } & { __typename: 'Query', preview?:
+    | { __typename: 'NodeArticle' }
+    | { __typename: 'NodeGoArticle', id: string, title: string, subtitle?: string | null, goArticleImage?:
+        | { __typename?: 'MediaAudio' }
+        | { __typename?: 'MediaDocument' }
+        | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+        | { __typename?: 'MediaVideo' }
+        | { __typename?: 'MediaVideotool' }
+       | null, publicationDate: { __typename?: 'DateTime', timestamp: unknown }, paragraphs?: Array<
+        | { __typename?: 'ParagraphAccordion' }
+        | { __typename?: 'ParagraphBanner' }
+        | { __typename?: 'ParagraphBreadcrumbChildren' }
+        | { __typename?: 'ParagraphCampaignRule' }
+        | { __typename?: 'ParagraphCardGridAutomatic' }
+        | { __typename?: 'ParagraphCardGridManual' }
+        | { __typename?: 'ParagraphContentSlider' }
+        | { __typename?: 'ParagraphContentSliderAutomatic' }
+        | { __typename?: 'ParagraphEventTicketCategory' }
+        | { __typename?: 'ParagraphFiles' }
+        | { __typename?: 'ParagraphFilteredEventList' }
+        | { __typename: 'ParagraphGoImages', goImages: Array<
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool' }
+          > }
+        | { __typename?: 'ParagraphGoLink' }
+        | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool' }
+           | null, goLinkParagraph:
+            | { __typename?: 'ParagraphAccordion' }
+            | { __typename?: 'ParagraphBanner' }
+            | { __typename?: 'ParagraphBreadcrumbChildren' }
+            | { __typename?: 'ParagraphCampaignRule' }
+            | { __typename?: 'ParagraphCardGridAutomatic' }
+            | { __typename?: 'ParagraphCardGridManual' }
+            | { __typename?: 'ParagraphContentSlider' }
+            | { __typename?: 'ParagraphContentSliderAutomatic' }
+            | { __typename?: 'ParagraphEventTicketCategory' }
+            | { __typename?: 'ParagraphFiles' }
+            | { __typename?: 'ParagraphFilteredEventList' }
+            | { __typename?: 'ParagraphGoImages' }
+            | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+            | { __typename?: 'ParagraphGoLinkbox' }
+            | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+            | { __typename?: 'ParagraphGoMaterialSliderManual' }
+            | { __typename?: 'ParagraphGoTextBody' }
+            | { __typename?: 'ParagraphGoVideo' }
+            | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+            | { __typename?: 'ParagraphGoVideoBundleManual' }
+            | { __typename?: 'ParagraphHero' }
+            | { __typename?: 'ParagraphLanguageSelector' }
+            | { __typename?: 'ParagraphLinks' }
+            | { __typename?: 'ParagraphManualEventList' }
+            | { __typename?: 'ParagraphMaterialGridAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridManual' }
+            | { __typename?: 'ParagraphMedias' }
+            | { __typename?: 'ParagraphNavGridManual' }
+            | { __typename?: 'ParagraphNavSpotsManual' }
+            | { __typename?: 'ParagraphOpeningHours' }
+            | { __typename?: 'ParagraphRecommendation' }
+            | { __typename?: 'ParagraphSimpleLinks' }
+            | { __typename?: 'ParagraphTextBody' }
+            | { __typename?: 'ParagraphUserRegistrationItem' }
+            | { __typename?: 'ParagraphUserRegistrationLinklist' }
+            | { __typename?: 'ParagraphUserRegistrationSection' }
+            | { __typename?: 'ParagraphVideo' }
+            | { __typename?: 'ParagraphWebform' }
+           }
+        | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+        | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+        | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+        | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+           }
+        | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+           }
+        | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+          , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+        | { __typename?: 'ParagraphHero' }
+        | { __typename?: 'ParagraphLanguageSelector' }
+        | { __typename?: 'ParagraphLinks' }
+        | { __typename?: 'ParagraphManualEventList' }
+        | { __typename?: 'ParagraphMaterialGridAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridManual' }
+        | { __typename?: 'ParagraphMedias' }
+        | { __typename?: 'ParagraphNavGridManual' }
+        | { __typename?: 'ParagraphNavSpotsManual' }
+        | { __typename?: 'ParagraphOpeningHours' }
+        | { __typename?: 'ParagraphRecommendation' }
+        | { __typename?: 'ParagraphSimpleLinks' }
+        | { __typename?: 'ParagraphTextBody' }
+        | { __typename?: 'ParagraphUserRegistrationItem' }
+        | { __typename?: 'ParagraphUserRegistrationLinklist' }
+        | { __typename?: 'ParagraphUserRegistrationSection' }
+        | { __typename?: 'ParagraphVideo' }
+        | { __typename?: 'ParagraphWebform' }
+      > | null }
+    | { __typename: 'NodeGoCategory', id: string, path?: string | null, title: string, paragraphs?: Array<
+        | { __typename?: 'ParagraphAccordion' }
+        | { __typename?: 'ParagraphBanner' }
+        | { __typename?: 'ParagraphBreadcrumbChildren' }
+        | { __typename?: 'ParagraphCampaignRule' }
+        | { __typename?: 'ParagraphCardGridAutomatic' }
+        | { __typename?: 'ParagraphCardGridManual' }
+        | { __typename?: 'ParagraphContentSlider' }
+        | { __typename?: 'ParagraphContentSliderAutomatic' }
+        | { __typename?: 'ParagraphEventTicketCategory' }
+        | { __typename?: 'ParagraphFiles' }
+        | { __typename?: 'ParagraphFilteredEventList' }
+        | { __typename: 'ParagraphGoImages', goImages: Array<
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool' }
+          > }
+        | { __typename?: 'ParagraphGoLink' }
+        | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool' }
+           | null, goLinkParagraph:
+            | { __typename?: 'ParagraphAccordion' }
+            | { __typename?: 'ParagraphBanner' }
+            | { __typename?: 'ParagraphBreadcrumbChildren' }
+            | { __typename?: 'ParagraphCampaignRule' }
+            | { __typename?: 'ParagraphCardGridAutomatic' }
+            | { __typename?: 'ParagraphCardGridManual' }
+            | { __typename?: 'ParagraphContentSlider' }
+            | { __typename?: 'ParagraphContentSliderAutomatic' }
+            | { __typename?: 'ParagraphEventTicketCategory' }
+            | { __typename?: 'ParagraphFiles' }
+            | { __typename?: 'ParagraphFilteredEventList' }
+            | { __typename?: 'ParagraphGoImages' }
+            | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+            | { __typename?: 'ParagraphGoLinkbox' }
+            | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+            | { __typename?: 'ParagraphGoMaterialSliderManual' }
+            | { __typename?: 'ParagraphGoTextBody' }
+            | { __typename?: 'ParagraphGoVideo' }
+            | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+            | { __typename?: 'ParagraphGoVideoBundleManual' }
+            | { __typename?: 'ParagraphHero' }
+            | { __typename?: 'ParagraphLanguageSelector' }
+            | { __typename?: 'ParagraphLinks' }
+            | { __typename?: 'ParagraphManualEventList' }
+            | { __typename?: 'ParagraphMaterialGridAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridManual' }
+            | { __typename?: 'ParagraphMedias' }
+            | { __typename?: 'ParagraphNavGridManual' }
+            | { __typename?: 'ParagraphNavSpotsManual' }
+            | { __typename?: 'ParagraphOpeningHours' }
+            | { __typename?: 'ParagraphRecommendation' }
+            | { __typename?: 'ParagraphSimpleLinks' }
+            | { __typename?: 'ParagraphTextBody' }
+            | { __typename?: 'ParagraphUserRegistrationItem' }
+            | { __typename?: 'ParagraphUserRegistrationLinklist' }
+            | { __typename?: 'ParagraphUserRegistrationSection' }
+            | { __typename?: 'ParagraphVideo' }
+            | { __typename?: 'ParagraphWebform' }
+           }
+        | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+        | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+        | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+        | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+           }
+        | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+           }
+        | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+          , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+        | { __typename?: 'ParagraphHero' }
+        | { __typename?: 'ParagraphLanguageSelector' }
+        | { __typename?: 'ParagraphLinks' }
+        | { __typename?: 'ParagraphManualEventList' }
+        | { __typename?: 'ParagraphMaterialGridAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridManual' }
+        | { __typename?: 'ParagraphMedias' }
+        | { __typename?: 'ParagraphNavGridManual' }
+        | { __typename?: 'ParagraphNavSpotsManual' }
+        | { __typename?: 'ParagraphOpeningHours' }
+        | { __typename?: 'ParagraphRecommendation' }
+        | { __typename?: 'ParagraphSimpleLinks' }
+        | { __typename?: 'ParagraphTextBody' }
+        | { __typename?: 'ParagraphUserRegistrationItem' }
+        | { __typename?: 'ParagraphUserRegistrationLinklist' }
+        | { __typename?: 'ParagraphUserRegistrationSection' }
+        | { __typename?: 'ParagraphVideo' }
+        | { __typename?: 'ParagraphWebform' }
+      > | null }
+    | { __typename: 'NodeGoPage', paragraphs?: Array<
+        | { __typename?: 'ParagraphAccordion' }
+        | { __typename?: 'ParagraphBanner' }
+        | { __typename?: 'ParagraphBreadcrumbChildren' }
+        | { __typename?: 'ParagraphCampaignRule' }
+        | { __typename?: 'ParagraphCardGridAutomatic' }
+        | { __typename?: 'ParagraphCardGridManual' }
+        | { __typename?: 'ParagraphContentSlider' }
+        | { __typename?: 'ParagraphContentSliderAutomatic' }
+        | { __typename?: 'ParagraphEventTicketCategory' }
+        | { __typename?: 'ParagraphFiles' }
+        | { __typename?: 'ParagraphFilteredEventList' }
+        | { __typename: 'ParagraphGoImages', goImages: Array<
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool' }
+          > }
+        | { __typename?: 'ParagraphGoLink' }
+        | { __typename: 'ParagraphGoLinkbox', title: string, goColor?: string | null, goDescription: string, goImage?:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage', name: string, byline?: string | null, mediaImage: { __typename?: 'Image', url: string, alt?: string | null, height: number, width: number, mime?: string | null, size: number, title?: string | null } }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool' }
+           | null, goLinkParagraph:
+            | { __typename?: 'ParagraphAccordion' }
+            | { __typename?: 'ParagraphBanner' }
+            | { __typename?: 'ParagraphBreadcrumbChildren' }
+            | { __typename?: 'ParagraphCampaignRule' }
+            | { __typename?: 'ParagraphCardGridAutomatic' }
+            | { __typename?: 'ParagraphCardGridManual' }
+            | { __typename?: 'ParagraphContentSlider' }
+            | { __typename?: 'ParagraphContentSliderAutomatic' }
+            | { __typename?: 'ParagraphEventTicketCategory' }
+            | { __typename?: 'ParagraphFiles' }
+            | { __typename?: 'ParagraphFilteredEventList' }
+            | { __typename?: 'ParagraphGoImages' }
+            | { __typename?: 'ParagraphGoLink', targetBlank?: boolean | null, ariaLabel?: string | null, link: { __typename?: 'Link', title?: string | null, url?: string | null } }
+            | { __typename?: 'ParagraphGoLinkbox' }
+            | { __typename?: 'ParagraphGoMaterialSliderAutomatic' }
+            | { __typename?: 'ParagraphGoMaterialSliderManual' }
+            | { __typename?: 'ParagraphGoTextBody' }
+            | { __typename?: 'ParagraphGoVideo' }
+            | { __typename?: 'ParagraphGoVideoBundleAutomatic' }
+            | { __typename?: 'ParagraphGoVideoBundleManual' }
+            | { __typename?: 'ParagraphHero' }
+            | { __typename?: 'ParagraphLanguageSelector' }
+            | { __typename?: 'ParagraphLinks' }
+            | { __typename?: 'ParagraphManualEventList' }
+            | { __typename?: 'ParagraphMaterialGridAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+            | { __typename?: 'ParagraphMaterialGridManual' }
+            | { __typename?: 'ParagraphMedias' }
+            | { __typename?: 'ParagraphNavGridManual' }
+            | { __typename?: 'ParagraphNavSpotsManual' }
+            | { __typename?: 'ParagraphOpeningHours' }
+            | { __typename?: 'ParagraphRecommendation' }
+            | { __typename?: 'ParagraphSimpleLinks' }
+            | { __typename?: 'ParagraphTextBody' }
+            | { __typename?: 'ParagraphUserRegistrationItem' }
+            | { __typename?: 'ParagraphUserRegistrationLinklist' }
+            | { __typename?: 'ParagraphUserRegistrationSection' }
+            | { __typename?: 'ParagraphVideo' }
+            | { __typename?: 'ParagraphWebform' }
+           }
+        | { __typename: 'ParagraphGoMaterialSliderAutomatic', sliderAmountOfMaterials: number, titleOptional: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null }
+        | { __typename: 'ParagraphGoMaterialSliderManual', titleOptional: string, materialSliderWorkIds: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> }
+        | { __typename: 'ParagraphGoTextBody', body: { __typename?: 'Text', processed?: unknown | null } }
+        | { __typename: 'ParagraphGoVideo', id: string, title: string, created: { __typename?: 'DateTime', timestamp: unknown }, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+           }
+        | { __typename: 'ParagraphGoVideoBundleAutomatic', goVideoTitle: string, videoAmountOfMaterials: number, id: string, cqlSearch?: { __typename?: 'CQLSearch', value?: string | null } | null, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+           }
+        | { __typename: 'ParagraphGoVideoBundleManual', id: string, goVideoTitle: string, embedVideo:
+            | { __typename?: 'MediaAudio' }
+            | { __typename?: 'MediaDocument' }
+            | { __typename?: 'MediaImage' }
+            | { __typename?: 'MediaVideo' }
+            | { __typename?: 'MediaVideotool', id: string, name: string, mediaVideotool: string }
+          , videoBundleWorkIds?: Array<{ __typename?: 'WorkId', material_type?: string | null, work_id?: string | null }> | null }
+        | { __typename?: 'ParagraphHero' }
+        | { __typename?: 'ParagraphLanguageSelector' }
+        | { __typename?: 'ParagraphLinks' }
+        | { __typename?: 'ParagraphManualEventList' }
+        | { __typename?: 'ParagraphMaterialGridAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridLinkAutomatic' }
+        | { __typename?: 'ParagraphMaterialGridManual' }
+        | { __typename?: 'ParagraphMedias' }
+        | { __typename?: 'ParagraphNavGridManual' }
+        | { __typename?: 'ParagraphNavSpotsManual' }
+        | { __typename?: 'ParagraphOpeningHours' }
+        | { __typename?: 'ParagraphRecommendation' }
+        | { __typename?: 'ParagraphSimpleLinks' }
+        | { __typename?: 'ParagraphTextBody' }
+        | { __typename?: 'ParagraphUserRegistrationItem' }
+        | { __typename?: 'ParagraphUserRegistrationLinklist' }
+        | { __typename?: 'ParagraphUserRegistrationSection' }
+        | { __typename?: 'ParagraphVideo' }
+        | { __typename?: 'ParagraphWebform' }
+      > | null }
+    | { __typename: 'NodePage' }
+   | null };
 
 export type GetAdgangsplatformenLibraryTokenQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2512,9 +3638,6 @@ export const GetDplCmsPublicConfigurationDocument = `
     query getDplCmsPublicConfiguration {
   goConfiguration {
     public {
-      searchProfiles {
-        local
-      }
       libraryInfo {
         name
       }

--- a/lib/graphql/generated/fbi/graphql.ts
+++ b/lib/graphql/generated/fbi/graphql.ts
@@ -174,6 +174,7 @@ export type ComplexSearchFacetsEnum =
   | 'GENERALMATERIALTYPE'
   | 'GENREANDFORM'
   | 'HOSTPUBLICATION'
+  | 'HOSTPUBLICATIONTYPE'
   | 'INSTRUMENT'
   | 'ISSUE'
   | 'LANGUAGE'
@@ -305,6 +306,76 @@ export type Complexity = {
   value: Scalars['Int']['output'];
 };
 
+export type ContentEntry = {
+  __typename?: 'ContentEntry';
+  /** Additional 'authors' (lyricists, arrangers, performers/soloists etc.), quoted as strings (including possible author's statement) from the record */
+  contributors?: Maybe<Array<Scalars['String']['output']>>;
+  /** Main creator(s) of the entry i.e. composer (classical music), artist/band (rhythmic music), author (fiction, articles). For music and sheet music always only 1 creator, for articles and fiction possibly more than 1 */
+  creators?: Maybe<ContentEntryCreators>;
+  /** Playing time for music tracks, quoted from the record */
+  playingTime?: Maybe<Scalars['String']['output']>;
+  /** Possible entry data (title, creators, contributors, playingtime) subordinate to the entry's top level */
+  sublevel?: Maybe<Array<ContentSublevel>>;
+  /** Top level title of the entry */
+  title: ContentEntryTitle;
+};
+
+export type ContentEntryCreators = {
+  __typename?: 'ContentEntryCreators';
+  /** Details about a corporation or conference, name, role, etc. */
+  corporations?: Maybe<Array<Corporation>>;
+  /** Details about a person, name, role etc. */
+  persons?: Maybe<Array<Person>>;
+};
+
+export type ContentEntryTitle = {
+  __typename?: 'ContentEntryTitle';
+  /** Title of the content entry */
+  display: Scalars['String']['output'];
+};
+
+export type ContentSublevel = {
+  __typename?: 'ContentSublevel';
+  /** Additional 'authors' (lyricists, arrangers, performers/soloists etc.) related to the title on sublevel 1, quoted as strings (including possible author's statement) from the record */
+  contributors?: Maybe<Array<Scalars['String']['output']>>;
+  /** Playing time for music tracks */
+  playingTime?: Maybe<Scalars['String']['output']>;
+  /** Possible entry data (title, contributors, playingtime) subordinate to the entry's sublevel 1 */
+  sublevel?: Maybe<Array<ContentSublevelLast>>;
+  /** Title subordinate to the title in the entry's top level */
+  title: ContentEntryTitle;
+};
+
+export type ContentSublevelLast = {
+  __typename?: 'ContentSublevelLast';
+  /** Additional 'authors' (lyricists, arrangers, performers/soloists etc.) related to the title on sublevel 1, quoted as strings (including possible author's statement) from the record */
+  contributors?: Maybe<Array<Scalars['String']['output']>>;
+  /** Playing time for music tracks */
+  playingTime?: Maybe<Scalars['String']['output']>;
+  /** Title subordinate to the title in the entry's top level */
+  title: ContentEntryTitle;
+};
+
+export type ContentsEntity = {
+  __typename?: 'ContentsEntity';
+  /** Content entry with title and possible creator(s), contributors and (for some music and movies) playing time */
+  entries?: Maybe<Array<ContentEntry>>;
+  /** Heading for the contents of this entity */
+  heading: Scalars['String']['output'];
+  /** Contents text note quoted as it is from the marc field. Used for non-machine-decipherable content notes (un)formatted in only 1 subfield) */
+  raw?: Maybe<Scalars['String']['output']>;
+  /** ENUM for type of content entries (music tracks, articles, fiction etc.) in this entity */
+  type: ContentsEntityEnum;
+};
+
+export type ContentsEntityEnum =
+  | 'ARTICLES'
+  | 'CHAPTERS'
+  | 'FICTION'
+  | 'MUSIC_TRACKS'
+  | 'NOT_SPECIFIED'
+  | 'SHEET_MUSIC';
+
 export type CopyRequestInput = {
   authorOfComponent?: InputMaybe<Scalars['String']['input']>;
   issueOfComponent?: InputMaybe<Scalars['String']['input']>;
@@ -364,6 +435,8 @@ export type Corporation = CreatorInterface & SubjectInterface & {
   /** Sub corporation or conference/meeting */
   sub?: Maybe<Scalars['String']['output']>;
   type: SubjectTypeEnum;
+  /** VIAF identifier of the creator */
+  viafid?: Maybe<Scalars['String']['output']>;
   /** Year of the conference */
   year?: Maybe<Scalars['String']['output']>;
 };
@@ -378,6 +451,7 @@ export type Cover = {
   large?: Maybe<CoverDetails>;
   medium?: Maybe<CoverDetails>;
   origin?: Maybe<Scalars['String']['output']>;
+  original?: Maybe<CoverDetails>;
   small?: Maybe<CoverDetails>;
   thumbnail?: Maybe<Scalars['String']['output']>;
   xSmall?: Maybe<CoverDetails>;
@@ -397,6 +471,8 @@ export type CreatorInterface = {
   nameSort: Scalars['String']['output'];
   /** A list of which kinds of contributions this creator made to this creation */
   roles: Array<Role>;
+  /** VIAF identifier of the creator */
+  viafid?: Maybe<Scalars['String']['output']>;
 };
 
 export type Dk5MainEntry = {
@@ -784,6 +860,8 @@ export type Manifestation = {
   cataloguedPublicationStatus?: Maybe<CataloguedPublicationStatus>;
   /** Classification codes for this manifestation from any classification system */
   classifications: Array<Classification>;
+  /** Content title entries with possible creators, contributors and playing time for music tracks, sheet music titles, articles, poems, short stories etc. */
+  contents?: Maybe<Array<ContentsEntity>>;
   /** Contributors to the manifestation, actors, illustrators etc */
   contributors: Array<CreatorInterface>;
   /** Additional contributors of this manifestation as described on the publication. E.g. 'på dansk ved Vivi Berendt' */
@@ -812,10 +890,11 @@ export type Manifestation = {
   latestPrinting?: Maybe<Printing>;
   /** Identification of the local id of this manifestation */
   localId?: Maybe<Scalars['String']['output']>;
-  /** Tracks on music album, sheet music content, or articles/short stories etc. in this manifestation */
+  /**
+   * Tracks on music album, sheet music content, or articles/short stories etc. in this manifestation
+   * @deprecated Use 'Manifestation.contents' instead expires: 01/11-2025
+   */
   manifestationParts?: Maybe<ManifestationParts>;
-  /** Field for presenting bibliographic records in MARC format */
-  marc?: Maybe<MarcRecord>;
   /** The type of material of the manifestation based on bibliotek.dk types */
   materialTypes: Array<MaterialType>;
   /** Notes about the manifestation */
@@ -846,7 +925,10 @@ export type Manifestation = {
   source: Array<Scalars['String']['output']>;
   /** Subjects for this manifestation */
   subjects: SubjectContainer;
-  /** Quotation of the manifestation's table of contents or a similar content list */
+  /**
+   * Quotation of the manifestation's table of contents or a similar content list
+   * @deprecated Use 'Manifestation.contents' instead expires: 01/11-2025
+   */
   tableOfContents?: Maybe<TableOfContent>;
   /** Different kinds of titles for this work */
   titles: ManifestationTitles;
@@ -950,22 +1032,6 @@ export type Manifestations = {
    * Only one manifestation per unit is returned.
    */
   searchHits?: Maybe<Array<SearchHit>>;
-};
-
-export type MarcRecord = {
-  __typename?: 'MarcRecord';
-  /** The library agency */
-  agencyId: Scalars['String']['output'];
-  /** The bibliographic record identifier */
-  bibliographicRecordId: Scalars['String']['output'];
-  /** The MARC record collection content as marcXchange XML string */
-  content: Scalars['String']['output'];
-  /** The serialization format of the MARC record content. Defaults to 'marcXchange' */
-  contentSerializationFormat: Scalars['String']['output'];
-  /** Flag indicating whether or not the record is deleted */
-  deleted: Scalars['Boolean']['output'];
-  /** The marc record identifier */
-  id: Scalars['String']['output'];
 };
 
 export type MaterialType = {
@@ -1223,6 +1289,8 @@ export type Person = CreatorInterface & SubjectInterface & {
   /** A roman numeral added to the person, like Christian IV */
   romanNumeral?: Maybe<Scalars['String']['output']>;
   type: SubjectTypeEnum;
+  /** VIAF identifier of the creator */
+  viafid?: Maybe<Scalars['String']['output']>;
 };
 
 export type PhysicalUnitDescription = {
@@ -1998,8 +2066,6 @@ export type Work = {
   mainLanguages: Array<Language>;
   /** Details about the manifestations of this work */
   manifestations: Manifestations;
-  /** Field for presenting bibliographic records in MARC format */
-  marc?: Maybe<MarcRecord>;
   /** The type of material of the manifestation based on bibliotek.dk types */
   materialTypes: Array<MaterialType>;
   /** Relations to other manifestations */
@@ -2069,51 +2135,151 @@ export type ManifestationCoverFragment = { __typename?: 'Manifestation', pid: st
 
 export type ManifestationIdentifiersFragment = { __typename?: 'Manifestation', pid: string, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }> };
 
-export type ManifestationAccessFragment = { __typename?: 'Manifestation', accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }> };
+export type ManifestationAccessFragment = { __typename?: 'Manifestation', accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+    | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+    | { __typename: 'DigitalArticleService', issn: string }
+    | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+    | { __typename: 'InfomediaService', id: string }
+    | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+  > };
 
 export type ManifestationTitlesFragment = { __typename?: 'Manifestation', titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> } };
 
 export type ManifestationLanguagesFragment = { __typename?: 'Manifestation', languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null };
 
-export type ManifestationDescriptionFragment = { __typename?: 'Manifestation', audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Mood', display: string } | { __typename?: 'NarrativeTechnique', display: string } | { __typename?: 'Person', display: string } | { __typename?: 'Setting', display: string } | { __typename?: 'SubjectText', display: string } | { __typename?: 'SubjectWithRating', display: string } | { __typename?: 'TimePeriod', display: string }> } };
+export type ManifestationDescriptionFragment = { __typename?: 'Manifestation', audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<
+      | { __typename?: 'Corporation', display: string }
+      | { __typename?: 'Mood', display: string }
+      | { __typename?: 'NarrativeTechnique', display: string }
+      | { __typename?: 'Person', display: string }
+      | { __typename?: 'Setting', display: string }
+      | { __typename?: 'SubjectText', display: string }
+      | { __typename?: 'SubjectWithRating', display: string }
+      | { __typename?: 'TimePeriod', display: string }
+    > } };
 
-export type ManifestationDetailsFragment = { __typename?: 'Manifestation', genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> };
+export type ManifestationDetailsFragment = { __typename?: 'Manifestation', genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+    | { __typename?: 'Corporation', display: string }
+    | { __typename?: 'Person', display: string }
+  > };
 
 export type ManifestationMaterialTypesFragment = { __typename?: 'Manifestation', materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }> };
 
-export type ManifestationSearchPageTeaserFragment = { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> };
+export type ManifestationSearchPageTeaserFragment = { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+    | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+    | { __typename: 'DigitalArticleService', issn: string }
+    | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+    | { __typename: 'InfomediaService', id: string }
+    | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+  >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+    | { __typename?: 'Corporation', display: string }
+    | { __typename?: 'Person', display: string }
+  > };
 
-export type ManifestationWorkPageFragment = { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Mood', display: string } | { __typename?: 'NarrativeTechnique', display: string } | { __typename?: 'Person', display: string } | { __typename?: 'Setting', display: string } | { __typename?: 'SubjectText', display: string } | { __typename?: 'SubjectWithRating', display: string } | { __typename?: 'TimePeriod', display: string }> }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> };
+export type ManifestationWorkPageFragment = { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+    | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+    | { __typename: 'DigitalArticleService', issn: string }
+    | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+    | { __typename: 'InfomediaService', id: string }
+    | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+  >, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<
+      | { __typename?: 'Corporation', display: string }
+      | { __typename?: 'Mood', display: string }
+      | { __typename?: 'NarrativeTechnique', display: string }
+      | { __typename?: 'Person', display: string }
+      | { __typename?: 'Setting', display: string }
+      | { __typename?: 'SubjectText', display: string }
+      | { __typename?: 'SubjectWithRating', display: string }
+      | { __typename?: 'TimePeriod', display: string }
+    > }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+    | { __typename?: 'Corporation', display: string }
+    | { __typename?: 'Person', display: string }
+  > };
 
-export type WorkAccessFragment = { __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }> }> } };
+export type WorkAccessFragment = { __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+        | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+        | { __typename: 'DigitalArticleService', issn: string }
+        | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+        | { __typename: 'InfomediaService', id: string }
+        | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+      > }> } };
 
 export type WorkMaterialTypesFragment = { __typename?: 'Work', materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }> };
 
 export type WorkTitlesFragment = { __typename?: 'Work', titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null } };
 
-export type WorkCreatorsFragment = { __typename?: 'Work', creators: Array<{ __typename: 'Corporation', display: string } | { __typename: 'Person', display: string }> };
+export type WorkCreatorsFragment = { __typename?: 'Work', creators: Array<
+    | { __typename: 'Corporation', display: string }
+    | { __typename: 'Person', display: string }
+  > };
 
 export type WorkPublicationYearFragment = { __typename?: 'Work', workYear?: { __typename?: 'PublicationYear', display: string } | null };
 
 export type WorkDescriptionFragment = { __typename?: 'Work', abstract?: Array<string> | null };
 
-export type WorkTeaserSearchPageFragment = { __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<{ __typename: 'Corporation', display: string } | { __typename: 'Person', display: string }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null };
+export type WorkTeaserSearchPageFragment = { __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+        | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+        | { __typename: 'DigitalArticleService', issn: string }
+        | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+        | { __typename: 'InfomediaService', id: string }
+        | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+      >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+        | { __typename?: 'Corporation', display: string }
+        | { __typename?: 'Person', display: string }
+      > }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+        | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+        | { __typename: 'DigitalArticleService', issn: string }
+        | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+        | { __typename: 'InfomediaService', id: string }
+        | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+      >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+        | { __typename?: 'Corporation', display: string }
+        | { __typename?: 'Person', display: string }
+      > } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<
+    | { __typename: 'Corporation', display: string }
+    | { __typename: 'Person', display: string }
+  >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null };
 
-export type WorkFullWorkPageFragment = { __typename?: 'Work', workId: string, abstract?: Array<string> | null, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Mood', display: string } | { __typename?: 'NarrativeTechnique', display: string } | { __typename?: 'Person', display: string } | { __typename?: 'Setting', display: string } | { __typename?: 'SubjectText', display: string } | { __typename?: 'SubjectWithRating', display: string } | { __typename?: 'TimePeriod', display: string }> }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Mood', display: string } | { __typename?: 'NarrativeTechnique', display: string } | { __typename?: 'Person', display: string } | { __typename?: 'Setting', display: string } | { __typename?: 'SubjectText', display: string } | { __typename?: 'SubjectWithRating', display: string } | { __typename?: 'TimePeriod', display: string }> }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<{ __typename: 'Corporation', display: string } | { __typename: 'Person', display: string }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null };
-
-export type GetThumbnailCoversByPidsQueryVariables = Exact<{
-  pids: Array<Scalars['String']['input']> | Scalars['String']['input'];
-}>;
-
-
-export type GetThumbnailCoversByPidsQuery = { __typename?: 'Query', manifestations: Array<{ __typename?: 'Manifestation', pid: string, cover: { __typename?: 'Cover', thumbnail?: string | null } } | null> };
-
-export type GetCoversByPidsQueryVariables = Exact<{
-  pids: Array<Scalars['String']['input']> | Scalars['String']['input'];
-}>;
-
-
-export type GetCoversByPidsQuery = { __typename?: 'Query', manifestations: Array<{ __typename?: 'Manifestation', pid: string, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null } } | null> };
+export type WorkFullWorkPageFragment = { __typename?: 'Work', workId: string, abstract?: Array<string> | null, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+        | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+        | { __typename: 'DigitalArticleService', issn: string }
+        | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+        | { __typename: 'InfomediaService', id: string }
+        | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+      >, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<
+          | { __typename?: 'Corporation', display: string }
+          | { __typename?: 'Mood', display: string }
+          | { __typename?: 'NarrativeTechnique', display: string }
+          | { __typename?: 'Person', display: string }
+          | { __typename?: 'Setting', display: string }
+          | { __typename?: 'SubjectText', display: string }
+          | { __typename?: 'SubjectWithRating', display: string }
+          | { __typename?: 'TimePeriod', display: string }
+        > }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+        | { __typename?: 'Corporation', display: string }
+        | { __typename?: 'Person', display: string }
+      > }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+        | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+        | { __typename: 'DigitalArticleService', issn: string }
+        | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+        | { __typename: 'InfomediaService', id: string }
+        | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+      >, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<
+          | { __typename?: 'Corporation', display: string }
+          | { __typename?: 'Mood', display: string }
+          | { __typename?: 'NarrativeTechnique', display: string }
+          | { __typename?: 'Person', display: string }
+          | { __typename?: 'Setting', display: string }
+          | { __typename?: 'SubjectText', display: string }
+          | { __typename?: 'SubjectWithRating', display: string }
+          | { __typename?: 'TimePeriod', display: string }
+        > }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+        | { __typename?: 'Corporation', display: string }
+        | { __typename?: 'Person', display: string }
+      > } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<
+    | { __typename: 'Corporation', display: string }
+    | { __typename: 'Person', display: string }
+  >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null };
 
 export type SearchWithPaginationQueryVariables = Exact<{
   q: SearchQueryInput;
@@ -2123,7 +2289,28 @@ export type SearchWithPaginationQueryVariables = Exact<{
 }>;
 
 
-export type SearchWithPaginationQuery = { __typename?: 'Query', search: { __typename?: 'SearchResponse', hitcount: number, works: Array<{ __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<{ __typename: 'Corporation', display: string } | { __typename: 'Person', display: string }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null }> } };
+export type SearchWithPaginationQuery = { __typename?: 'Query', search: { __typename?: 'SearchResponse', hitcount: number, works: Array<{ __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+            | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+            | { __typename: 'DigitalArticleService', issn: string }
+            | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+            | { __typename: 'InfomediaService', id: string }
+            | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+          >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+            | { __typename?: 'Corporation', display: string }
+            | { __typename?: 'Person', display: string }
+          > }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+            | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+            | { __typename: 'DigitalArticleService', issn: string }
+            | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+            | { __typename: 'InfomediaService', id: string }
+            | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+          >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+            | { __typename?: 'Corporation', display: string }
+            | { __typename?: 'Person', display: string }
+          > } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<
+        | { __typename: 'Corporation', display: string }
+        | { __typename: 'Person', display: string }
+      >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null }> } };
 
 export type SearchFacetsQueryVariables = Exact<{
   q: SearchQueryInput;
@@ -2143,14 +2330,74 @@ export type ComplexSearchForWorkTeaserQueryVariables = Exact<{
 }>;
 
 
-export type ComplexSearchForWorkTeaserQuery = { __typename?: 'Query', complexSearch: { __typename?: 'ComplexSearchResponse', hitcount: number, works: Array<{ __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<{ __typename: 'Corporation', display: string } | { __typename: 'Person', display: string }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null }> } };
+export type ComplexSearchForWorkTeaserQuery = { __typename?: 'Query', complexSearch: { __typename?: 'ComplexSearchResponse', hitcount: number, works: Array<{ __typename?: 'Work', workId: string, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+            | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+            | { __typename: 'DigitalArticleService', issn: string }
+            | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+            | { __typename: 'InfomediaService', id: string }
+            | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+          >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+            | { __typename?: 'Corporation', display: string }
+            | { __typename?: 'Person', display: string }
+          > }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+            | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+            | { __typename: 'DigitalArticleService', issn: string }
+            | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+            | { __typename: 'InfomediaService', id: string }
+            | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+          >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+            | { __typename?: 'Corporation', display: string }
+            | { __typename?: 'Person', display: string }
+          > } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<
+        | { __typename: 'Corporation', display: string }
+        | { __typename: 'Person', display: string }
+      >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null }> } };
 
 export type GetMaterialQueryVariables = Exact<{
   wid: Scalars['String']['input'];
 }>;
 
 
-export type GetMaterialQuery = { __typename?: 'Query', work?: { __typename?: 'Work', workId: string, abstract?: Array<string> | null, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Mood', display: string } | { __typename?: 'NarrativeTechnique', display: string } | { __typename?: 'Person', display: string } | { __typename?: 'Setting', display: string } | { __typename?: 'SubjectText', display: string } | { __typename?: 'SubjectWithRating', display: string } | { __typename?: 'TimePeriod', display: string }> }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<{ __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean } | { __typename: 'DigitalArticleService', issn: string } | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean } | { __typename: 'InfomediaService', id: string } | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }>, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Mood', display: string } | { __typename?: 'NarrativeTechnique', display: string } | { __typename?: 'Person', display: string } | { __typename?: 'Setting', display: string } | { __typename?: 'SubjectText', display: string } | { __typename?: 'SubjectWithRating', display: string } | { __typename?: 'TimePeriod', display: string }> }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<{ __typename?: 'Corporation', display: string } | { __typename?: 'Person', display: string }> } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<{ __typename: 'Corporation', display: string } | { __typename: 'Person', display: string }>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null } | null };
+export type GetMaterialQuery = { __typename?: 'Query', work?: { __typename?: 'Work', workId: string, abstract?: Array<string> | null, manifestations: { __typename?: 'Manifestations', all: Array<{ __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+          | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+          | { __typename: 'DigitalArticleService', issn: string }
+          | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+          | { __typename: 'InfomediaService', id: string }
+          | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+        >, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<
+            | { __typename?: 'Corporation', display: string }
+            | { __typename?: 'Mood', display: string }
+            | { __typename?: 'NarrativeTechnique', display: string }
+            | { __typename?: 'Person', display: string }
+            | { __typename?: 'Setting', display: string }
+            | { __typename?: 'SubjectText', display: string }
+            | { __typename?: 'SubjectWithRating', display: string }
+            | { __typename?: 'TimePeriod', display: string }
+          > }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+          | { __typename?: 'Corporation', display: string }
+          | { __typename?: 'Person', display: string }
+        > }>, bestRepresentation: { __typename?: 'Manifestation', pid: string, genreAndForm: Array<string>, publisher: Array<string>, contributorsFromDescription: Array<string>, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', code: GeneralMaterialTypeCodeEnum, display: string } }>, identifiers: Array<{ __typename?: 'Identifier', type: IdentifierTypeEnum, value: string }>, cover: { __typename?: 'Cover', thumbnail?: string | null, xSmall?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, small?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, medium?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null, large?: { __typename?: 'CoverDetails', url?: string | null, width?: number | null, height?: number | null } | null }, accessTypes: Array<{ __typename?: 'AccessType', code: AccessTypeCodeEnum, display: string }>, access: Array<
+          | { __typename: 'AccessUrl', origin: string, url: string, loginRequired: boolean }
+          | { __typename: 'DigitalArticleService', issn: string }
+          | { __typename: 'Ereol', origin: string, url: string, canAlwaysBeLoaned: boolean }
+          | { __typename: 'InfomediaService', id: string }
+          | { __typename: 'InterLibraryLoan', loanIsPossible: boolean }
+        >, titles: { __typename?: 'ManifestationTitles', identifyingAddition?: string | null, full: Array<string> }, languages?: { __typename?: 'Languages', main?: Array<{ __typename?: 'Language', display: string, isoCode: string }> | null } | null, audience?: { __typename?: 'Audience', ages: Array<{ __typename?: 'Range', display: string }> } | null, series: Array<{ __typename?: 'Series', numberInSeries?: string | null, title: string }>, subjects: { __typename?: 'SubjectContainer', all: Array<
+            | { __typename?: 'Corporation', display: string }
+            | { __typename?: 'Mood', display: string }
+            | { __typename?: 'NarrativeTechnique', display: string }
+            | { __typename?: 'Person', display: string }
+            | { __typename?: 'Setting', display: string }
+            | { __typename?: 'SubjectText', display: string }
+            | { __typename?: 'SubjectWithRating', display: string }
+            | { __typename?: 'TimePeriod', display: string }
+          > }, physicalDescription?: { __typename?: 'PhysicalUnitDescription', summaryFull?: string | null } | null, dateFirstEdition?: { __typename?: 'PublicationYear', display: string } | null, edition?: { __typename?: 'Edition', contributors: Array<string>, edition?: string | null, summary: string, publicationYear?: { __typename?: 'PublicationYear', display: string, year?: number | null } | null } | null, contributors: Array<
+          | { __typename?: 'Corporation', display: string }
+          | { __typename?: 'Person', display: string }
+        > } }, titles: { __typename?: 'WorkTitles', full: Array<string>, original?: Array<string> | null }, creators: Array<
+      | { __typename: 'Corporation', display: string }
+      | { __typename: 'Person', display: string }
+    >, materialTypes: Array<{ __typename?: 'MaterialType', materialTypeGeneral: { __typename?: 'GeneralMaterialType', display: string, code: GeneralMaterialTypeCodeEnum } }>, workYear?: { __typename?: 'PublicationYear', display: string } | null } | null };
 
 
 export const SearchFacetFragmentDoc = `
@@ -2425,126 +2672,6 @@ ${WorkMaterialTypesFragmentDoc}
 ${WorkPublicationYearFragmentDoc}
 ${WorkDescriptionFragmentDoc}
 ${ManifestationWorkPageFragmentDoc}`;
-export const GetThumbnailCoversByPidsDocument = `
-    query GetThumbnailCoversByPids($pids: [String!]!) {
-  manifestations(pid: $pids) {
-    pid
-    cover {
-      thumbnail
-    }
-  }
-}
-    `;
-
-export const useGetThumbnailCoversByPidsQuery = <
-      TData = GetThumbnailCoversByPidsQuery,
-      TError = unknown
-    >(
-      variables: GetThumbnailCoversByPidsQueryVariables,
-      options?: Omit<UseQueryOptions<GetThumbnailCoversByPidsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<GetThumbnailCoversByPidsQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useQuery<GetThumbnailCoversByPidsQuery, TError, TData>(
-      {
-    queryKey: ['GetThumbnailCoversByPids', variables],
-    queryFn: fetchData<GetThumbnailCoversByPidsQuery, GetThumbnailCoversByPidsQueryVariables>(GetThumbnailCoversByPidsDocument, variables),
-    ...options
-  }
-    )};
-
-useGetThumbnailCoversByPidsQuery.getKey = (variables: GetThumbnailCoversByPidsQueryVariables) => ['GetThumbnailCoversByPids', variables];
-
-export const useSuspenseGetThumbnailCoversByPidsQuery = <
-      TData = GetThumbnailCoversByPidsQuery,
-      TError = unknown
-    >(
-      variables: GetThumbnailCoversByPidsQueryVariables,
-      options?: Omit<UseSuspenseQueryOptions<GetThumbnailCoversByPidsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseSuspenseQueryOptions<GetThumbnailCoversByPidsQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useSuspenseQuery<GetThumbnailCoversByPidsQuery, TError, TData>(
-      {
-    queryKey: ['GetThumbnailCoversByPidsSuspense', variables],
-    queryFn: fetchData<GetThumbnailCoversByPidsQuery, GetThumbnailCoversByPidsQueryVariables>(GetThumbnailCoversByPidsDocument, variables),
-    ...options
-  }
-    )};
-
-useSuspenseGetThumbnailCoversByPidsQuery.getKey = (variables: GetThumbnailCoversByPidsQueryVariables) => ['GetThumbnailCoversByPidsSuspense', variables];
-
-
-useGetThumbnailCoversByPidsQuery.fetcher = (variables: GetThumbnailCoversByPidsQueryVariables, options?: RequestInit['headers']) => fetchData<GetThumbnailCoversByPidsQuery, GetThumbnailCoversByPidsQueryVariables>(GetThumbnailCoversByPidsDocument, variables, options);
-
-export const GetCoversByPidsDocument = `
-    query GetCoversByPids($pids: [String!]!) {
-  manifestations(pid: $pids) {
-    pid
-    cover {
-      thumbnail
-      xSmall {
-        url
-        width
-        height
-      }
-      small {
-        url
-        width
-        height
-      }
-      medium {
-        url
-        width
-        height
-      }
-      large {
-        url
-        width
-        height
-      }
-    }
-  }
-}
-    `;
-
-export const useGetCoversByPidsQuery = <
-      TData = GetCoversByPidsQuery,
-      TError = unknown
-    >(
-      variables: GetCoversByPidsQueryVariables,
-      options?: Omit<UseQueryOptions<GetCoversByPidsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<GetCoversByPidsQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useQuery<GetCoversByPidsQuery, TError, TData>(
-      {
-    queryKey: ['GetCoversByPids', variables],
-    queryFn: fetchData<GetCoversByPidsQuery, GetCoversByPidsQueryVariables>(GetCoversByPidsDocument, variables),
-    ...options
-  }
-    )};
-
-useGetCoversByPidsQuery.getKey = (variables: GetCoversByPidsQueryVariables) => ['GetCoversByPids', variables];
-
-export const useSuspenseGetCoversByPidsQuery = <
-      TData = GetCoversByPidsQuery,
-      TError = unknown
-    >(
-      variables: GetCoversByPidsQueryVariables,
-      options?: Omit<UseSuspenseQueryOptions<GetCoversByPidsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseSuspenseQueryOptions<GetCoversByPidsQuery, TError, TData>['queryKey'] }
-    ) => {
-    
-    return useSuspenseQuery<GetCoversByPidsQuery, TError, TData>(
-      {
-    queryKey: ['GetCoversByPidsSuspense', variables],
-    queryFn: fetchData<GetCoversByPidsQuery, GetCoversByPidsQueryVariables>(GetCoversByPidsDocument, variables),
-    ...options
-  }
-    )};
-
-useSuspenseGetCoversByPidsQuery.getKey = (variables: GetCoversByPidsQueryVariables) => ['GetCoversByPidsSuspense', variables];
-
-
-useGetCoversByPidsQuery.fetcher = (variables: GetCoversByPidsQueryVariables, options?: RequestInit['headers']) => fetchData<GetCoversByPidsQuery, GetCoversByPidsQueryVariables>(GetCoversByPidsDocument, variables, options);
-
 export const SearchWithPaginationDocument = `
     query searchWithPagination($q: SearchQueryInput!, $offset: Int!, $limit: PaginationLimitScalar!, $filters: SearchFiltersInput) {
   search(q: $q, filters: $filters) {
@@ -2743,8 +2870,6 @@ useGetMaterialQuery.fetcher = (variables: GetMaterialQueryVariables, options?: R
 
 export const operationNames = {
   Query: {
-    GetThumbnailCoversByPids: 'GetThumbnailCoversByPids' as const,
-    GetCoversByPids: 'GetCoversByPids' as const,
     searchWithPagination: 'searchWithPagination' as const,
     searchFacets: 'searchFacets' as const,
     complexSearchForWorkTeaser: 'complexSearchForWorkTeaser' as const,

--- a/lib/graphql/queries/configuration.dpl-cms.graphql
+++ b/lib/graphql/queries/configuration.dpl-cms.graphql
@@ -14,9 +14,6 @@ query getDplCmsPrivateConfiguration {
 query getDplCmsPublicConfiguration {
   goConfiguration {
     public {
-      searchProfiles {
-        local
-      }
       libraryInfo {
         name
       }

--- a/lib/helpers/ap-service.ts
+++ b/lib/helpers/ap-service.ts
@@ -15,19 +15,6 @@ export const getApServiceUrl = async (serviceType: TServiceType) => {
     throw new Error(`No url found for the ${serviceType} service`)
   }
 
-  if (serviceType === "fbi") {
-    const dplCmsConfig = await getDplCmsPublicConfig()
-
-    if (!dplCmsConfig.searchProfiles.local) {
-      throw new Error("DPL CMS searchProfiles.local is not defined")
-    }
-
-    return serviceSettings.url.replace(
-      "{search_profile_placeholder}",
-      dplCmsConfig.searchProfiles.local
-    )
-  }
-
   return serviceSettings.url
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ci-check": "yarn typecheck && yarn lint && yarn format:check && yarn test:unit:once",
     "codegen:all-rest-services": "orval",
     "codegen:fbs": "rm -rf src/lib/rest/fbs/generated/model/*.* && orval --project fbs",
-    "codegen:graphql": "NODE_ENV=development DOTENV_CONFIG_PATH=./.env.local NODE_TLS_REJECT_UNAUTHORIZED=0 graphql-codegen -r dotenv/config --require tsconfig-paths/register --config codegen.ts",
+    "codegen:graphql": "NODE_ENV=development SKIP_ENV_VALIDATION=1 NODE_TLS_REJECT_UNAUTHORIZED=0 graphql-codegen --require tsconfig-paths/register --config codegen.ts",
     "codegen:publizon": "rm -rf lib/rest/publizon-api/generated/* && orval --project publizonAdapter && orval --project publizonLocalAdapter",
     "codegen:pubhub": "rm -rf lib/soap/publizon/v2_7/generated/* && npx tsx ./scripts/wsdl-tsclient/publizon-wsdl-codegen",
     "codegen:unilogin": "rm -rf lib/soap/unilogin/wsiinst-v5/generated/* && npx tsx ./scripts/wsdl-tsclient/unilogin-wsdl-codegen",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDF-34

#### Description

Go has its own search profile now. We'll hardcode it as it's not supposed to vary across sites.

#### Additional comments or questions

This is not done, there's some codegen that needs to be run, but according to the docs it's:

```shell
yarn codegen:graphql
```

Well...

```shell
~/d/d/dpl-go ▶ yarn codegen:graphql
fish: Unknown command: yarn
```

And no `docker-compose.yml` to get a containerized environment. So I'm passing the buck to the frontenders.
